### PR TITLE
adding a function based dispatch.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,10 @@ History
 0.5.0 (UNRELEASED)
 ------------------
 
+* structure/unstructure now supports using functions as well as classes for deciding the appropriate function.
+* added `Converter.register_structure_hook_func`, to register a function instead of a class for determining handler func
+* added `Converter.register_unstructure_hook_func`, to register a function instead of a class for determining handler func
+
 
 0.4.0 (2017-07-17)
 ------------------

--- a/cattr/__init__.py
+++ b/cattr/__init__.py
@@ -17,4 +17,6 @@ structure = global_converter.structure
 structure_attrs_fromtuple = global_converter.structure_attrs_fromtuple
 structure_attrs_fromdict = global_converter.structure_attrs_fromdict
 register_structure_hook = global_converter.register_structure_hook
+register_structure_hook_func = global_converter.register_structure_hook_func
 register_unstructure_hook = global_converter.register_unstructure_hook
+register_unstructure_hook_func = global_converter.register_unstructure_hook_func

--- a/cattr/__init__.py
+++ b/cattr/__init__.py
@@ -19,4 +19,5 @@ structure_attrs_fromdict = global_converter.structure_attrs_fromdict
 register_structure_hook = global_converter.register_structure_hook
 register_structure_hook_func = global_converter.register_structure_hook_func
 register_unstructure_hook = global_converter.register_unstructure_hook
-register_unstructure_hook_func = global_converter.register_unstructure_hook_func
+register_unstructure_hook_func = \
+    global_converter.register_unstructure_hook_func

--- a/cattr/_compat.py
+++ b/cattr/_compat.py
@@ -7,8 +7,12 @@ use_vendored_typing = (
 is_py2 = version_info[0] == 2
 is_py3 = version_info[0] == 3
 
-from typing import *  # noqa
-from typing import _Union  # noqa
+if is_py2 or use_vendored_typing:
+    from .vendor.typing import *  # noqa
+    from .vendor.typing import _Union  # noqa
+else:
+    from typing import *  # noqa
+    from typing import _Union  # noqa
 
 if is_py2:
     from functools32 import lru_cache

--- a/cattr/_compat.py
+++ b/cattr/_compat.py
@@ -7,12 +7,8 @@ use_vendored_typing = (
 is_py2 = version_info[0] == 2
 is_py3 = version_info[0] == 3
 
-if is_py2 or use_vendored_typing:
-    from .vendor.typing import *  # noqa
-    from .vendor.typing import _Union  # noqa
-else:
-    from typing import *  # noqa
-    from typing import _Union  # noqa
+from typing import *  # noqa
+from typing import _Union  # noqa
 
 if is_py2:
     from functools32 import lru_cache

--- a/cattr/converters.py
+++ b/cattr/converters.py
@@ -25,9 +25,11 @@ class UnstructureStrategy(Enum):
 def _is_attrs_class(cls):
     return getattr(cls, "__attrs_attrs__", None) is not None
 
+
 def _is_union_type(obj):
     """ returns true if the object is an instance of union. """
     return isinstance(obj, _Union)
+
 
 def _subclass(typ):
     """ a shortcut """

--- a/cattr/converters.py
+++ b/cattr/converters.py
@@ -90,7 +90,7 @@ class Converter(object):
         # Strings are sequences.
         self.structure_func.register_cls_list([
             (unicode, self._structure_unicode if is_py2
-                      else self._structure_call),
+             else self._structure_call),
             (bytes, self._structure_call),
             (int, self._structure_call),
             (float, self._structure_call),

--- a/cattr/function_dispatch.py
+++ b/cattr/function_dispatch.py
@@ -5,7 +5,6 @@ class FunctionDispatch(object):
     first argument in the method, and return True or False.
 
     objects that help determine dispatch should be instantiated objects.
-
     """
 
     def __init__(self):
@@ -14,6 +13,7 @@ class FunctionDispatch(object):
 
     def register(self, can_handle, func):
         self._handler_pairs.insert(0, (can_handle, func))
+        self._cache.clear()
 
     def dispatch(self, typ):
         """

--- a/cattr/function_dispatch.py
+++ b/cattr/function_dispatch.py
@@ -1,0 +1,38 @@
+class FunctionDispatch(object):
+    """
+    FunctionDispatch is similar to functools.singledispatch, but
+    instead dispatches based on functions that take the type of the
+    first argument in the method, and return True or False.
+
+    objects that help determine dispatch should be instantiated objects.
+
+    """
+
+    def __init__(self):
+        self._handler_pairs = []
+        self._cache = {}
+
+    def register(self, can_handle, func):
+        self._handler_pairs.insert(0, (can_handle, func))
+
+    def dispatch(self, typ):
+        """
+        returns the appropriate handler, for the object passed.
+        """
+        try:
+            return self._cache[typ]
+        except KeyError:
+            self._cache[typ] = self._dispatch(typ)
+            return self._cache[typ]
+
+    def _dispatch(self, typ):
+        for can_handle, handler in self._handler_pairs:
+            # can handle could raise an exception here
+            # such as issubclass being called on an instance.
+            # it's easier to just ignore that case.
+            try:
+                if can_handle(typ):
+                    return handler
+            except:
+                pass
+        raise KeyError("unable to find handler for {0}".format(obj))

--- a/cattr/function_dispatch.py
+++ b/cattr/function_dispatch.py
@@ -1,3 +1,7 @@
+import attr
+
+
+@attr.s
 class FunctionDispatch(object):
     """
     FunctionDispatch is similar to functools.singledispatch, but
@@ -6,10 +10,8 @@ class FunctionDispatch(object):
 
     objects that help determine dispatch should be instantiated objects.
     """
-
-    def __init__(self):
-        self._handler_pairs = []
-        self._cache = {}
+    _handler_pairs = attr.ib(init=False, default=attr.Factory(list))
+    _cache = attr.ib(init=False, default=attr.Factory(dict))
 
     def register(self, can_handle, func):
         self._handler_pairs.insert(0, (can_handle, func))

--- a/cattr/function_dispatch.py
+++ b/cattr/function_dispatch.py
@@ -33,6 +33,6 @@ class FunctionDispatch(object):
             try:
                 if can_handle(typ):
                     return handler
-            except:
+            except Exception:
                 pass
-        raise KeyError("unable to find handler for {0}".format(obj))
+        raise KeyError("unable to find handler for {0}".format(typ))

--- a/cattr/multistrategy_dispatch.py
+++ b/cattr/multistrategy_dispatch.py
@@ -1,0 +1,40 @@
+from .function_dispatch import FunctionDispatch
+from ._compat import singledispatch
+
+
+class MultiStrategyDispatch(object):
+    """
+    MultiStrategyDispatch uses a
+    combination of function dispatch and singledispatch.
+
+    FunctionDispatches are used first, then uses singledispatch otherwise.
+    """
+
+    def __init__(self, fallback_func):
+        self._function_dispatch = FunctionDispatch()
+        self._function_dispatch.register(lambda cls: True, fallback_func)
+        self._single_dispatch = singledispatch(lambda: None)
+        del self._single_dispatch.registry[object]
+        self._cache = {}
+
+    def dispatch(self, cl):
+        if cl not in self._cache:
+            found = False
+            try:
+                dispatch = self._single_dispatch.dispatch(cl)
+                if dispatch is not None:
+                    found = True
+            except Exception:
+                pass
+            if not found:
+                dispatch = self._function_dispatch.dispatch(cl)
+            self._cache[cl] = dispatch
+        return self._cache[cl]
+
+    def register_cls(self, cls, handler):
+        """ register a class, which utilizes singledispatch """
+        self._single_dispatch.register(cls, handler)
+
+    def register_func(self, func, handler):
+        """ register a function to determine if the handle should be used for the type """
+        self._function_dispatch.register(func, handler)

--- a/cattr/multistrategy_dispatch.py
+++ b/cattr/multistrategy_dispatch.py
@@ -37,11 +37,12 @@ class MultiStrategyDispatch(object):
             self._cache[cl] = dispatch
         return self._cache[cl]
 
-    def register_cls(self, cls, handler):
+    def register_cls_list(self, cls_and_handler):
         """ register a class to singledispatch """
-        self._single_dispatch.register(cls, handler)
-        if cls in self._cache:
-            del self._cache[cls]
+        for cls, handler in cls_and_handler:
+            self._single_dispatch.register(cls, handler)
+            if cls in self._cache:
+                del self._cache[cls]
 
     def register_func_list(self, func_and_handler):
         """ register a function to determine if the handle

--- a/cattr/multistrategy_dispatch.py
+++ b/cattr/multistrategy_dispatch.py
@@ -1,7 +1,9 @@
+import attr
 from .function_dispatch import FunctionDispatch
 from ._compat import singledispatch
 
 
+@attr.s
 class _DispatchNotFound(object):
     """ a dummy object to help signify a dispatch not found """
     pass

--- a/cattr/multistrategy_dispatch.py
+++ b/cattr/multistrategy_dispatch.py
@@ -14,8 +14,22 @@ class MultiStrategyDispatch(object):
         self._function_dispatch = FunctionDispatch()
         self._function_dispatch.register(lambda cls: True, fallback_func)
         self._single_dispatch = singledispatch(lambda: None)
-        del self._single_dispatch.registry[object]
+        self._clear_registry(self._single_dispatch)
         self._cache = {}
+
+    @staticmethod
+    def _clear_registry(singledispatch_instance):
+        """
+        a hack to clear the singledispatch registry.
+
+        this ensures that singledispatch does not resolve for
+        types that are not explicitly registered to it.
+        """
+        register_closure = singledispatch_instance.register.__closure__
+        for cell in register_closure:
+            if isinstance(cell.cell_contents, dict):
+                if object in cell.cell_contents:
+                    del cell.cell_contents[object]
 
     def dispatch(self, cl):
         if cl not in self._cache:

--- a/cattr/multistrategy_dispatch.py
+++ b/cattr/multistrategy_dispatch.py
@@ -30,7 +30,7 @@ class MultiStrategyDispatch(object):
                 dispatch = self._single_dispatch.dispatch(cl)
                 if dispatch is not _DispatchNotFound:
                     found = True
-            except Exception as e:
+            except Exception:
                 pass
             if not found:
                 dispatch = self._function_dispatch.dispatch(cl)

--- a/docs/structuring.rst
+++ b/docs/structuring.rst
@@ -386,3 +386,23 @@ The type may seem redundant but is useful when dealing with generic types.
 
 When using ``cattr.register_structure_hook``, the hook will be registered on the global converter.
 If you want to avoid changing the global converter, create an instance of ``cattr.Converter`` and register the hook on that.
+
+In some situations, it is not possible to decide on the converter using typing mechanisms alone (such as with attrs classes). In these situations,
+cattrs provides a register_structure_func_hook instead, which accepts a function to determine whether that type can be handled instead.
+
+The function-based hooks are evaluated after the class-based hooks. In the case where both a class-based hook and a function-based hook are present, the class-based hook will be used.
+
+.. doctest::
+
+    >>> class D(object):
+    ...     custom = True
+    ...     def __init__(self, a):
+    ...         self.a = a
+    ...     def __repr__(self):
+    ...         return f'D(a={self.a})'
+    ...     @classmethod
+    ...     def deserialize(cls, data):
+    ...         return cls(data["a"])
+    >>> cattr.register_structure_hook_func(lambda cls: getattr(cls, "custom", False), lambda d, t: t.deserialize(d))
+    >>> cattr.structure({'a': 2}, D)
+    D(a=2)

--- a/setup.py
+++ b/setup.py
@@ -19,14 +19,8 @@ if sys.version_info < (3, 0):
         "functools32 >= 3.2.3; python_version<'3.0'",
         "singledispatch >= 3.4.0.3; python_version<'3.0'",
         "enum34 >= 1.1.6; python_version<'3.0'",
-        # TODO: uncomment this for when vendor/python2/typing.py can be
-        # removed. This will be for a version > 3.6.1 that has a fix that
-        # allows singledispatch to work with parameterized generic types (cf
-        # github/python/typing#405)
-        #
-        # "typing >= 3.5.3; python_version<'3.0'",
+        "typing >= 3.5.3; python_version<'3.0'",
     ])
-
 
 setup(
     name='cattrs',

--- a/tests/metadata/test_roundtrips.py
+++ b/tests/metadata/test_roundtrips.py
@@ -88,6 +88,7 @@ def test_optional_field_roundtrip(converter, cl_and_vals):
         a = typed(Optional[cl])
 
     inst = C(a=cl(*vals))
+    assert inst == converter.structure(converter.unstructure(inst), C)
 
     inst = C(a=None)
     unstructured = converter.unstructure(inst)

--- a/tests/metadata/test_roundtrips.py
+++ b/tests/metadata/test_roundtrips.py
@@ -89,8 +89,6 @@ def test_optional_field_roundtrip(converter, cl_and_vals):
 
     inst = C(a=cl(*vals))
 
-    assert inst == converter.structure(converter.unstructure(inst), C)
-
     inst = C(a=None)
     unstructured = converter.unstructure(inst)
 

--- a/tests/test_function_dispatch.py
+++ b/tests/test_function_dispatch.py
@@ -1,0 +1,38 @@
+import pytest
+from cattr.function_dispatch import FunctionDispatch
+
+
+def test_function_dispatch():
+    dispatch = FunctionDispatch()
+
+    with pytest.raises(KeyError):
+        dispatch.dispatch(float)
+
+    def test_func():
+        return "test"
+
+    dispatch.register(
+        lambda cls: issubclass(cls, float),
+        test_func
+    )
+
+    assert dispatch.dispatch(float) == test_func
+
+
+def test_function_clears_cache_after_function_added():
+    dispatch = FunctionDispatch()
+
+    class Foo(object):
+        pass
+
+    class Bar(Foo):
+        pass
+
+    dispatch.register(
+        lambda cls: issubclass(cls, Foo), "foo"
+    )
+    assert dispatch.dispatch(Bar) == "foo"
+    dispatch.register(
+        lambda cls: issubclass(cls, Bar), "bar"
+    )
+    assert dispatch.dispatch(Bar) == "bar"

--- a/tests/test_function_dispatch.py
+++ b/tests/test_function_dispatch.py
@@ -8,8 +8,7 @@ def test_function_dispatch():
     with pytest.raises(KeyError):
         dispatch.dispatch(float)
 
-    def test_func():
-        return "test"
+    test_func = object()
 
     dispatch.register(
         lambda cls: issubclass(cls, float),
@@ -24,9 +23,11 @@ def test_function_clears_cache_after_function_added():
 
     class Foo(object):
         pass
+    Foo()
 
     class Bar(Foo):
         pass
+    Bar()
 
     dispatch.register(
         lambda cls: issubclass(cls, Foo), "foo"

--- a/tests/test_multistrategy_dispatch.py
+++ b/tests/test_multistrategy_dispatch.py
@@ -16,11 +16,13 @@ def _foo_func():
 def _foo_cls():
     pass
 
+
 def test_multistrategy_dispatch_register_cls():
     dispatch = MultiStrategyDispatch(_fallback)
     assert dispatch.dispatch(Foo) == _fallback
     dispatch.register_cls_list([(Foo, _foo_cls)])
     assert dispatch.dispatch(Foo) == _foo_cls
+
 
 def test_multistrategy_dispatch_register_func():
     dispatch = MultiStrategyDispatch(_fallback)
@@ -29,6 +31,7 @@ def test_multistrategy_dispatch_register_func():
         (lambda cls: issubclass(cls, Foo), _foo_func)
     ])
     assert dispatch.dispatch(Foo) == _foo_func
+
 
 def test_multistrategy_dispatch_conflict_class_wins():
     """

--- a/tests/test_multistrategy_dispatch.py
+++ b/tests/test_multistrategy_dispatch.py
@@ -18,6 +18,9 @@ def _foo_cls():
 
 
 def test_multistrategy_dispatch_register_cls():
+    _fallback()
+    _foo_func()
+    _foo_cls()
     dispatch = MultiStrategyDispatch(_fallback)
     assert dispatch.dispatch(Foo) == _fallback
     dispatch.register_cls_list([(Foo, _foo_cls)])

--- a/tests/test_multistrategy_dispatch.py
+++ b/tests/test_multistrategy_dispatch.py
@@ -1,0 +1,44 @@
+from cattr.multistrategy_dispatch import MultiStrategyDispatch
+
+
+class Foo(object):
+    pass
+
+
+def _fallback():
+    pass
+
+
+def _foo_func():
+    pass
+
+
+def _foo_cls():
+    pass
+
+def test_multistrategy_dispatch_register_cls():
+    dispatch = MultiStrategyDispatch(_fallback)
+    assert dispatch.dispatch(Foo) == _fallback
+    dispatch.register_cls_list([(Foo, _foo_cls)])
+    assert dispatch.dispatch(Foo) == _foo_cls
+
+def test_multistrategy_dispatch_register_func():
+    dispatch = MultiStrategyDispatch(_fallback)
+    assert dispatch.dispatch(Foo) == _fallback
+    dispatch.register_func_list([
+        (lambda cls: issubclass(cls, Foo), _foo_func)
+    ])
+    assert dispatch.dispatch(Foo) == _foo_func
+
+def test_multistrategy_dispatch_conflict_class_wins():
+    """
+    When a class dispatch and a function dispatch
+    are registered which handle the same type, the
+    class dispatch should return.
+    """
+    dispatch = MultiStrategyDispatch(_fallback)
+    dispatch.register_func_list([
+        (lambda cls: issubclass(cls, Foo), _foo_func)
+    ])
+    dispatch.register_cls_list([(Foo, _foo_cls)])
+    assert dispatch.dispatch(Foo) == _foo_cls

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -263,6 +263,28 @@ def test_structuring_primitive_union_hook(converter, ints):
             assert unicode(x) == y
 
 
+def test_structure_hook_func(converter):
+    """ testing the hook_func method """
+
+    def can_handle(cls):
+        return cls.__name__.startswith("F")
+
+    def handle(obj, cls):
+        return "hi"
+
+    class Foo(object):
+        pass
+
+    class Bar(object):
+        pass
+
+    converter.register_structure_hook_func(can_handle, handle)
+
+    assert converter.structure(10, Foo) == "hi"
+    with raises(ValueError):
+        converter.structure(10, Bar)
+
+
 @given(choices(), enums_of_primitives())
 def test_structuring_enums(converter, choice, enum):
     # type: (Converter, Any, Any) -> None

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -279,3 +279,23 @@ def test_structuring_unsupported(converter):
         converter.structure(1, Converter)
     with raises(ValueError):
         converter.structure(1, Union[int, unicode])
+
+
+def test_subclass_registration_is_honored(converter):
+    """ If a subclass is registered after a superclass,
+    that subclass handler should be dispatched for
+    structure
+    """
+    class Foo(object):
+        def __init__(self, value):
+            self.value = value
+
+    class Bar(Foo):
+        pass
+
+    converter.register_structure_hook(Foo, lambda obj, cls: cls("foo"))
+    assert converter.structure(None, Foo).value == "foo"
+    assert converter.structure(None, Bar).value == "foo"
+    converter.register_structure_hook(Bar, lambda obj, cls: cls("bar"))
+    assert converter.structure(None, Foo).value == "foo"
+    assert converter.structure(None, Bar).value == "bar"

--- a/tests/test_unstructure.py
+++ b/tests/test_unstructure.py
@@ -23,7 +23,8 @@ def test_seq_unstructure(converter, seq_and_type, dump_strat):
     seq = seq_and_type[0]
     dumped = converter.unstructure(seq)
     assert dumped == seq
-    assert dumped is not seq
+    if not isinstance(seq, tuple):
+        assert dumped is not seq
     assert type(dumped) is type(seq)
 
 

--- a/tests/test_unstructure.py
+++ b/tests/test_unstructure.py
@@ -82,7 +82,7 @@ def test_unstructure_hooks(converter, cl_and_vals):
     assert converter.unstructure(inst) == 'test'
 
 
-def test_unstructure_hook_func(converter, cl_and_vals):
+def test_unstructure_hook_func(converter):
     """
     Unstructure hooks work.
     """

--- a/tests/test_unstructure.py
+++ b/tests/test_unstructure.py
@@ -3,7 +3,6 @@ from . import (seqs_of_primitives, dicts_of_primitives, enums_of_primitives,
                simple_classes, nested_classes)
 
 from cattr.converters import UnstructureStrategy
-from pytest import raises
 
 from attr import asdict, astuple
 from hypothesis import given
@@ -82,8 +81,8 @@ def test_unstructure_hooks(converter, cl_and_vals):
 
     assert converter.unstructure(inst) == 'test'
 
-@given(simple_classes())
-def test_unstructure_hooks(converter, cl_and_vals):
+
+def test_unstructure_hook_func(converter, cl_and_vals):
     """
     Unstructure hooks work.
     """

--- a/tests/test_unstructure.py
+++ b/tests/test_unstructure.py
@@ -3,6 +3,7 @@ from . import (seqs_of_primitives, dicts_of_primitives, enums_of_primitives,
                simple_classes, nested_classes)
 
 from cattr.converters import UnstructureStrategy
+from pytest import raises
 
 from attr import asdict, astuple
 from hypothesis import given
@@ -80,3 +81,26 @@ def test_unstructure_hooks(converter, cl_and_vals):
     converter.register_unstructure_hook(cl, lambda val: 'test')
 
     assert converter.unstructure(inst) == 'test'
+
+@given(simple_classes())
+def test_unstructure_hooks(converter, cl_and_vals):
+    """
+    Unstructure hooks work.
+    """
+    def can_handle(cls):
+        return cls.__name__.startswith("F")
+
+    def handle(obj):
+        return "hi"
+
+    class Foo(object):
+        pass
+
+    class Bar(object):
+        pass
+
+    converter.register_unstructure_hook_func(can_handle, handle)
+
+    b = Bar()
+    assert converter.unstructure(Foo()) == "hi"
+    assert converter.unstructure(b) is b

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     -r{toxinidir}/requirements_dev.txt
 commands =
     pip install -U pip
-    coverage run --parallel -m pytest --basetemp={envtmpdir}
+    coverage run --parallel -m pytest --basetemp={envtmpdir} -sx
 
 [testenv:docs]
 basepython = python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     -r{toxinidir}/requirements_dev.txt
 commands =
     pip install -U pip
-    coverage run --parallel -m pytest --basetemp={envtmpdir} -sx
+    coverage run --parallel -m pytest --basetemp={envtmpdir}
 
 [testenv:docs]
 basepython = python3.6


### PR DESCRIPTION
This address #9.

A proof of concept PR, so I could do more polish on it. But it illustrates:

1. using a FunctionDispatch class vs SingleDispatch.
2. feature parity with SingleDispatch (including caching for quick lookup)

Tried it out locally, works with py27 and py36, sans the vendor typing library.

More improvements / changes:

- change the register function signature to take two functions, rather than type + function.
- use FunctionDispatch to also handle attrs