### PR TITLE
Ensure that LICENSE is included in the built wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,6 @@ omit =
 
 [bdist_wheel]
 universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
Without this directive it is not included: wheels ignore MANIFEST.in

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>