### PR TITLE
Add support for typing.ForwardDef

### DIFF
--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -9,6 +9,11 @@ from typing import (
     Tuple,
 )
 
+try:
+    from typing import ForwardRef
+except ImportError:
+    from typing import _ForwardRef as ForwardRef  # noqa
+
 version_info = sys.version_info[0:3]
 is_py2 = version_info[0] == 2
 is_py3 = version_info[0] == 3

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -143,13 +143,14 @@ class Converter(object):
         self._unstructure_func.register_cls_list([(cls, func)])
 
     def register_unstructure_hook_func(self, check_func, func):
+        # type: (Callable[Any], Callable[[T], Any]) -> None
         """Register a class-to-primitive converter function for a class, using
         a function to check if it's a match.
         """
-        # type: (Callable[Any], Callable[T], Any]) -> None
         self._unstructure_func.register_func_list([(check_func, func)])
 
     def register_structure_hook(self, cl, func):
+        # type: (Type[T], Callable[[Any, Type], T]) -> None
         """Register a primitive-to-class converter function for a type.
 
         The converter function should take two arguments:
@@ -159,21 +160,19 @@ class Converter(object):
         and return the instance of the class. The type may seem redundant, but
         is sometimes needed (for example, when dealing with generic classes).
         """
-        # type: (Type[T], Callable[[Any, Type], T) -> None
         if is_union_type(cl):
             self._union_registry[cl] = func
         else:
             self._structure_func.register_cls_list([(cl, func)])
 
     def register_structure_hook_func(self, check_func, func):
-        # type: (Callable[Any], Callable[T], Any]) -> None
+        # type: (Callable[Any], Callable[[T], Any]) -> None
         """Register a class-to-primitive converter function for a class, using
         a function to check if it's a match.
         """
         self._structure_func.register_func_list([(check_func, func)])
 
     def structure(self, obj, cl):
-        """Convert unstructured Python data structures to structured data."""
         # type: (Any, Type) -> Any
         return self._structure_func.dispatch(cl)(obj, cl)
 

--- a/tests/metadata/__init__.py
+++ b/tests/metadata/__init__.py
@@ -68,7 +68,7 @@ def _create_hyp_class(attrs_and_strategy):
 
 
 @composite
-def bare_typed_attrs(draw, defaults=None):
+def bare_typed_attrs(draw, defaults=None, deferred=None):
     """
     Generate a tuple of an attribute and a strategy that yields values
     appropriate for that attribute.
@@ -76,11 +76,15 @@ def bare_typed_attrs(draw, defaults=None):
     default = attr.NOTHING
     if defaults is True or (defaults is None and draw(booleans())):
         default = None
-    return (attr.ib(type=Any, default=default), just(None))
+    if deferred is None:
+        deferred = draw(booleans())
+
+    type_ = "Any" if deferred else Any
+    return (attr.ib(type=type_, default=default), just(None))
 
 
 @composite
-def int_typed_attrs(draw, defaults=None):
+def int_typed_attrs(draw, defaults=None, deferred=None):
     """
     Generate a tuple of an attribute and a strategy that yields ints for that
     attribute.
@@ -88,7 +92,11 @@ def int_typed_attrs(draw, defaults=None):
     default = attr.NOTHING
     if defaults is True or (defaults is None and draw(booleans())):
         default = draw(integers())
-    return (attr.ib(type=int, default=default), integers())
+    if deferred is None:
+        deferred = draw(booleans())
+
+    type_ = "int" if deferred else int
+    return (attr.ib(type=type_, default=default), integers())
 
 
 @composite
@@ -100,11 +108,12 @@ def str_typed_attrs(draw, defaults=None):
     default = NOTHING
     if defaults is True or (defaults is None and draw(booleans())):
         default = draw(text())
+
     return (attr.ib(type=unicode, default=default), text())
 
 
 @composite
-def float_typed_attrs(draw, defaults=None):
+def float_typed_attrs(draw, defaults=None, deferred=None):
     """
     Generate a tuple of an attribute and a strategy that yields floats for that
     attribute.
@@ -112,7 +121,11 @@ def float_typed_attrs(draw, defaults=None):
     default = attr.NOTHING
     if defaults is True or (defaults is None and draw(booleans())):
         default = draw(floats())
-    return (attr.ib(type=float, default=default), floats())
+    if deferred is None:
+        deferred = draw(booleans())
+
+    type_ = "float" if deferred else float
+    return (attr.ib(type=type_, default=default), floats())
 
 
 @composite

--- a/tests/metadata/test_roundtrips.py
+++ b/tests/metadata/test_roundtrips.py
@@ -7,7 +7,7 @@ from hypothesis import assume, given
 from hypothesis.strategies import sampled_from
 
 from cattr import Converter, UnstructureStrategy
-from typing import Union, Optional
+from typing import Any, Union, Optional  # noqa
 
 from . import simple_typed_classes, nested_typed_classes, simple_typed_attrs
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -315,7 +315,7 @@ def test_structure_hook_func(converter):
     def can_handle(cls):
         return cls.__name__.startswith("F")
 
-    def handle(obj, cls):
+    def handle(obj, cls, context):
         return "hi"
 
     class Foo(object):
@@ -362,9 +362,9 @@ def test_subclass_registration_is_honored(converter):
     class Bar(Foo):
         pass
 
-    converter.register_structure_hook(Foo, lambda obj, cls: cls("foo"))
+    converter.register_structure_hook(Foo, lambda obj, cls, _: cls("foo"))
     assert converter.structure(None, Foo).value == "foo"
     assert converter.structure(None, Bar).value == "foo"
-    converter.register_structure_hook(Bar, lambda obj, cls: cls("bar"))
+    converter.register_structure_hook(Bar, lambda obj, cls, _: cls("bar"))
     assert converter.structure(None, Foo).value == "foo"
     assert converter.structure(None, Bar).value == "bar"


### PR DESCRIPTION
Its also correct for type annotations to be strings that are evaluated at run time. Internally, Python converts them into typing.ForwardDef
objects and evals them at runtime. cattr needs to do the same thing as
well.

This also brings in compatibility for PEP 563 where deferred
evaluation becomes the default behaviour.