### PR TITLE
Implementing Generic Structuring Support

### DIFF
--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -73,7 +73,10 @@ if is_py37 or is_py38:
     bare_mutable_seq_args = MutableSequence.__args__
 
     def is_bare(type):
-        args = type.__args__
+        try:
+            args = type.__args__
+        except Exception as ex:
+            raise
         return (
             args == bare_list_args
             or args == bare_seq_args

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -83,8 +83,11 @@ if is_py37 or is_py38:
         )
 
 
+    def is_generic(obj):
+        return isinstance(obj, _GenericAlias)
+
 else:
-    from typing import _Union
+    from typing import _Union, GenericMeta
 
     def is_union_type(obj):
         """Return true if the object is a union. """
@@ -112,9 +115,9 @@ else:
     def is_bare(type):
         return not type.__args__
 
+    def is_generic(obj):
+        return isinstance(obj,GenericMeta)
+
     is_bare_frozenset = is_bare
 
 
-def is_generic_alias(obj):
-    from typing import _GenericAlias
-    return isinstance(obj, _GenericAlias)

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -29,10 +29,13 @@ else:
 
 
 if is_py38:
-    from typing import get_args
+    from typing import get_args, get_origin
 else:
     def get_args(cl):
         return cl.__args__
+
+    def get_origin(cl):
+        return cl.__origin__
 
 
 if is_py37 or is_py38:

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -113,3 +113,8 @@ else:
         return not type.__args__
 
     is_bare_frozenset = is_bare
+
+
+def is_generic_alias(obj):
+    from typing import _GenericAlias
+    return isinstance(obj, _GenericAlias)

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -86,6 +86,9 @@ if is_py37 or is_py38:
     def is_generic(obj):
         return isinstance(obj, _GenericAlias)
 
+    def is_attrs_class(cls):
+        return getattr(cls, "__attrs_attrs__", None) is not None
+
 else:
     from typing import _Union, GenericMeta
 
@@ -117,6 +120,9 @@ else:
 
     def is_generic(obj):
         return isinstance(obj,GenericMeta)
+
+    def is_attrs_class(cls):
+        return getattr(cls, "__attrs_attrs__", None) is not None and getattr(cls, "__args__", None) is None
 
     is_bare_frozenset = is_bare
 

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -27,6 +27,14 @@ else:
     unicode = str
     bytes = bytes
 
+
+if is_py38:
+    from typing import get_args
+else:
+    def get_args(cl):
+        return cl.__args__
+
+
 if is_py37 or is_py38:
     from typing import List, Union, _GenericAlias
 

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -377,6 +377,8 @@ class Converter(object):
 
     def _structure_list(self, obj, cl, mapping):
         """Convert an iterable to a potentially generic list."""
+        if isinstance(cl, TypeVar):
+            cl = getattr(mapping, cl.__name__, obj)
         if is_bare(cl) or cl.__args__[0] is Any:
             return [e for e in obj]
         else:
@@ -394,6 +396,8 @@ class Converter(object):
 
     def _structure_set(self, obj, cl, mapping):
         """Convert an iterable into a potentially generic set."""
+        if isinstance(cl, TypeVar):
+            cl = getattr(mapping, cl.__name__, obj)
         if is_bare(cl) or cl.__args__[0] is Any:
             return set(obj)
         else:
@@ -405,6 +409,8 @@ class Converter(object):
 
     def _structure_frozenset(self, obj, cl, mapping):
         """Convert an iterable into a potentially generic frozenset."""
+        if isinstance(cl, TypeVar):
+            cl = getattr(mapping, cl.__name__, obj)
         if is_bare(cl) or cl.__args__[0] is Any:
             return frozenset(obj)
         else:
@@ -414,6 +420,8 @@ class Converter(object):
 
     def _structure_dict(self, obj, cl, mapping):
         """Convert a mapping into a potentially generic dict."""
+        if isinstance(cl, TypeVar):
+            cl = getattr(mapping, cl.__name__, obj)
         if is_bare(cl) or cl.__args__ == (Any, Any):
             return dict(obj)
         else:

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -27,7 +27,7 @@ from ._compat import (
     is_union_type,
     lru_cache,
     unicode,
-    is_generic)
+    is_generic, is_attrs_class)
 from .disambiguators import create_uniq_field_dis_func
 from .multistrategy_dispatch import MultiStrategyDispatch
 
@@ -42,10 +42,6 @@ class UnstructureStrategy(Enum):
 
     AS_DICT = "asdict"
     AS_TUPLE = "astuple"
-
-
-def _is_attrs_class(cls):
-    return getattr(cls, "__attrs_attrs__", None) is not None
 
 
 def _subclass(typ):
@@ -97,7 +93,7 @@ class Converter(object):
                 (_subclass(Set), self._unstructure_seq),
                 (_subclass(FrozenSet), self._unstructure_seq),
                 (_subclass(Enum), self._unstructure_enum),
-                (_is_attrs_class, self._unstructure_attrs),
+                (is_attrs_class, self._unstructure_attrs),
             ]
         )
 
@@ -114,7 +110,8 @@ class Converter(object):
                 (is_tuple, self._structure_tuple),
                 (is_mapping, self._structure_dict),
                 (is_union_type, self._structure_union),
-                (_is_attrs_class, self._structure_attrs),
+                (is_attrs_class, self._structure_attrs),
+
             ]
         )
         # Strings are sequences.

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -478,7 +478,7 @@ class Converter(object):
         # Check the union registry first.
         handler = self._union_registry.get(union)
         if handler is not None:
-            return handler(obj, union)
+            return handler(obj, union, mapping)
 
         # Getting here means either this is not an optional, or it's an
         # optional with more than one parameter.

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -27,7 +27,7 @@ from ._compat import (
     is_union_type,
     lru_cache,
     unicode,
-    is_generic_alias)
+    is_generic)
 from .disambiguators import create_uniq_field_dis_func
 from .multistrategy_dispatch import MultiStrategyDispatch
 
@@ -107,7 +107,7 @@ class Converter(object):
         self._structure_func = MultiStrategyDispatch(self._structure_default)
         self._structure_func.register_func_list(
             [
-                (is_generic_alias, self._structure_generic),
+                (is_generic, self._structure_generic),
                 (is_sequence, self._structure_list),
                 (is_mutable_set, self._structure_set),
                 (is_frozenset, self._structure_frozenset),
@@ -340,7 +340,7 @@ class Converter(object):
         # For public use.
 
         for base in getattr(cl, "__orig_bases__", ()):
-            if is_generic_alias(base) and not str(base).startswith("typing.Generic"):
+            if is_generic(base) and not str(base).startswith("typing.Generic"):
                 mapping = self._generate_mapping(base)
                 break
 

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -12,7 +12,6 @@ from typing import (  # noqa: F401, imported for Mypy.
     Type,
     TypeVar,
     get_type_hints,
-    get_origin
 )
 
 from attr import make_class, attrib
@@ -29,7 +28,7 @@ from ._compat import (
     is_union_type,
     lru_cache,
     unicode,
-    is_generic, is_attrs_class, get_args)
+    is_generic, is_attrs_class, get_args, get_origin)
 from .disambiguators import create_uniq_field_dis_func
 from .multistrategy_dispatch import MultiStrategyDispatch
 

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -258,13 +258,17 @@ class Converter(object):
         )
         raise ValueError(msg)
 
-    def _structure_call(self, obj, cl, mapping):
+    def _structure_call(self, obj, cl, mappings):
         """Just call ``cl`` with the given ``obj``.
 
         This is just an optimization on the ``_structure_default`` case, when
         we know we can skip the ``if`` s. Use for ``str``, ``bytes``, ``enum``,
         etc.
         """
+        if isinstance(cl, TypeVar):
+            # We have a generic, lets try and check the mappings
+            cl = getattr(mappings, cl.__name__, cl)
+
         return cl(obj)
 
     def _structure_unicode(self, obj, cl, mapping):
@@ -320,7 +324,7 @@ class Converter(object):
 
         inst_mapping = cls(**mapping)
 
-        return self._mapped_structure_dispatch(base, inst_mapping)(obj)
+        return self._mapped_structure_dispatch(base, inst_mapping)(obj, base, inst_mapping)
 
     def structure_attrs_fromdict(self, obj, cl, mappings):
         # type: (Mapping[str, Any], Type[T], dict) -> T

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -336,6 +336,7 @@ class Converter(object):
 
         return self._mapped_structure_dispatch(base, mapping)(obj, base, mapping)
 
+    @lru_cache
     def _generate_mapping(self, cl: Type, old_mapping):
         mapping = {}
         for p, t in zip(get_origin(cl).__parameters__, get_args(cl)):

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -370,18 +370,24 @@ class Converter(object):
         if is_bare(cl) or cl.__args__[0] is Any:
             return [e for e in obj]
         else:
-            elem_type = cl.__args__[0]
+            elem_type = self._get_elem_type(cl, mapping)
             return [
                 self._mapped_structure_dispatch(elem_type, mapping)(e, elem_type, mapping)
                 for e in obj
             ]
+
+    def _get_elem_type(self, cl, mapping):
+        elem_type = cl.__args__[0]
+        if isinstance(elem_type, TypeVar):
+            return getattr(mapping, elem_type.__name__, elem_type)
+        return elem_type
 
     def _structure_set(self, obj, cl, mapping):
         """Convert an iterable into a potentially generic set."""
         if is_bare(cl) or cl.__args__[0] is Any:
             return set(obj)
         else:
-            elem_type = cl.__args__[0]
+            elem_type = self._get_elem_type(cl, mapping)
             return {
                 self._mapped_structure_dispatch(elem_type, mapping)(e, elem_type, mapping)
                 for e in obj
@@ -392,7 +398,7 @@ class Converter(object):
         if is_bare(cl) or cl.__args__[0] is Any:
             return frozenset(obj)
         else:
-            elem_type = cl.__args__[0]
+            elem_type = self._get_elem_type(cl, mapping)
             dispatch = self._mapped_structure_dispatch
             return frozenset(dispatch(elem_type, mapping)(e, elem_type, mapping) for e in obj)
 

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -352,6 +352,8 @@ class Converter(object):
         conv_obj = {}  # Start with a fresh dict, to ignore extra keys.
         dispatch = self._mapped_structure_dispatch
         for a in cl.__attrs_attrs__:  # type: ignore
+            if not a.init:
+                continue
             # We detect the type by metadata.
             type_ = a.type
             name = a.name

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -202,7 +202,10 @@ class Converter(object):
         for a in attrs:
             name = a.name
             v = getattr(obj, name)
-            rv[name] = dispatch(v.__class__)(v)
+            try:
+                rv[name] = dispatch(v.__class__)(v)
+            except Exception as ex:
+                raise
         return rv
 
     def unstructure_attrs_astuple(self, obj):
@@ -434,6 +437,8 @@ class Converter(object):
         # Unions with NoneType in them are basically optionals.
         # We check for NoneType early and handle the case of obj being None,
         # so disambiguation functions don't need to handle NoneType.
+        if isinstance(union, TypeVar):
+            union = getattr(mapping, union.__name__, union)
         union_params = union.__args__
         if NoneType in union_params:  # type: ignore
             if obj is None:

--- a/src/cattr/multistrategy_dispatch.py
+++ b/src/cattr/multistrategy_dispatch.py
@@ -1,5 +1,3 @@
-from typing import TypeVar
-
 import attr
 from .function_dispatch import FunctionDispatch
 from ._compat import singledispatch, lru_cache
@@ -16,7 +14,6 @@ class MultiStrategyDispatch(object):
     """
     MultiStrategyDispatch uses a
     combination of FunctionDispatch and singledispatch.
-
     singledispatch is attempted first. If nothing is
     registered for singledispatch, or an exception occurs,
     the FunctionDispatch instance is then used.
@@ -30,19 +27,14 @@ class MultiStrategyDispatch(object):
         self._single_dispatch = singledispatch(_DispatchNotFound)
         self.dispatch = lru_cache(64)(self._dispatch)
 
-    def _dispatch(self, cl, mappings: dict = None):
-        if isinstance(cl, TypeVar):
-            # We have a generic, lets try and check the mappings
-            cl = getattr(mappings, cl.__name__, cl)
-
+    def _dispatch(self, cl):
         try:
             dispatch = self._single_dispatch.dispatch(cl)
             if dispatch is not _DispatchNotFound:
-                return lambda x: dispatch(x, cl, mappings)
+                return dispatch
         except Exception:
             pass
-        dis = self._function_dispatch.dispatch(cl)
-        return lambda x: dis(x, cl, mappings)
+        return self._function_dispatch.dispatch(cl)
 
     def register_cls_list(self, cls_and_handler):
         """ register a class to singledispatch """


### PR DESCRIPTION
This is extremely rough and a first pass, it is a proof of concept to see if this is a direction that cattrs is willing to take or not. A working concept with this code can be found below.

```
from attr import attrs, attrib, make_class
from typing import Dict, Type, Optional, List, TypeVar, Generic
from cattr import structure

@attrs(auto_attribs=True)
class M(Generic[Q]):
    m: Q

@attrs(auto_attribs=True)
class N(Generic[P]):
    n: P

data2 = {
    "n": {
        "m": "test"
    }
}

a = structure(data2, N[M[str]])
print(a)
```

Right now when when you want to structure a generic it informs you to register a hook. From what I have found, to do this you have to register a call for every instance of your generic and you have to manually define how to build the object.

when you are talking multiple layers down, numerous different instances of the objects, this can become a tedious thing to maintain, especially when you are dealing with "simple" objects in terms of their structuring and destructuring are all ready supported if they were concrete types from the beginning. 

To handle generics I tried a couple different ways to implement this as purely an external addon, but I found it was impossible to get it right without injecting code into `MultiStrategyDispatch` to handle TypeVars. 

I also tried to not use lambdas but I found in every function block for the mutlifunction dispatcher I had to insert the:

```
        if isinstance(cl, TypeVar):
            cl = getattr(mappings, cl.__name__, cl)
```

This is why I added the lambdas. Mappings was needed in a few handlers list `_structure_list` which means I had to pass it around to all the different functions so all methods signatures needed to be modified.

`make_class` was needed because of the `lru_cache` as all parameters needed to be hashable and this was the best way I could come up with doing it.

This is my attempt to address the problem. This is a breaking change, and I know 1.0.0 is on the horizon, but I personally think this is a worth while change to make. There are a few cleanup tasks that need to be done, documentation would need updating and I have not even looked at the unit tests yet.  But I wanted to get some direction on if this is something worth pursuing and could be merged in.

I have only tested on python 3.7 so there is likely some other things that need fixing to support other versions.