### PR TITLE
Allow renaming of properties with attrs

### DIFF
--- a/src/cattr/__init__.py
+++ b/src/cattr/__init__.py
@@ -18,6 +18,7 @@ global_converter = Converter()
 
 unstructure = global_converter.unstructure
 structure = global_converter.structure
+ib = global_converter.ib
 structure_attrs_fromtuple = global_converter.structure_attrs_fromtuple
 structure_attrs_fromdict = global_converter.structure_attrs_fromdict
 register_structure_hook = global_converter.register_structure_hook

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -204,8 +204,9 @@ class Converter(object):
         rv = self._dict_factory()
         for a in attrs:
             name = a.name
+            from_key = a.metadata.get(CATTRS_METADATA_KEY, a.name)
             v = getattr(obj, name)
-            rv[name] = dispatch(v.__class__)(v)
+            rv[from_key] = dispatch(v.__class__)(v)
         return rv
 
     def unstructure_attrs_astuple(self, obj):

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -27,11 +27,15 @@ from ._compat import (
 )
 from .disambiguators import create_uniq_field_dis_func
 from .multistrategy_dispatch import MultiStrategyDispatch
+import attr
 
 
 NoneType = type(None)
 T = TypeVar("T")
 V = TypeVar("V")
+
+
+CATTRS_METADATA_KEY = 'cattrs_structure_key'
 
 
 class UnstructureStrategy(Enum):
@@ -301,9 +305,10 @@ class Converter(object):
             # We detect the type by metadata.
             type_ = a.type
             name = a.name
+            from_key = a.metadata.get(CATTRS_METADATA_KEY, a.name)
 
             try:
-                val = obj[name]
+                val = obj[from_key]
             except KeyError:
                 continue
 
@@ -433,3 +438,11 @@ class Converter(object):
                 "currently. Register a loads hook manually."
             )
         return create_uniq_field_dis_func(*union_types)
+
+    def ib(self, default=attr.NOTHING, validator=None, repr=True, cmp=True,
+           hash=None, init=True, convert=None, metadata={}, src_key=None):
+        metadata = dict() if not metadata else metadata
+        if src_key:
+            metadata[CATTRS_METADATA_KEY] = src_key
+        return attr.ib(default, validator, repr, cmp, hash,
+                       init, convert, metadata)

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -204,9 +204,10 @@ class Converter(object):
         rv = self._dict_factory()
         for a in attrs:
             name = a.name
-            from_key = a.metadata.get(CATTRS_METADATA_KEY, a.name)
+            # get src_key if any and unstrucutre to that instead of a.name
+            src_key = a.metadata.get(CATTRS_METADATA_KEY, a.name)
             v = getattr(obj, name)
-            rv[from_key] = dispatch(v.__class__)(v)
+            rv[src_key] = dispatch(v.__class__)(v)
         return rv
 
     def unstructure_attrs_astuple(self, obj):
@@ -306,10 +307,11 @@ class Converter(object):
             # We detect the type by metadata.
             type_ = a.type
             name = a.name
-            from_key = a.metadata.get(CATTRS_METADATA_KEY, a.name)
+            # get src_key if any and structure from there instead of a.name
+            src_key = a.metadata.get(CATTRS_METADATA_KEY, a.name)
 
             try:
-                val = obj[from_key]
+                val = obj[src_key]
             except KeyError:
                 continue
 
@@ -442,6 +444,13 @@ class Converter(object):
 
     def ib(self, default=attr.NOTHING, validator=None, repr=True, cmp=True,
            hash=None, init=True, convert=None, metadata={}, src_key=None):
+        """Custom verion of attr.ib with extra parameter src_key.
+
+        src_key will be stored in the attr metadata. The property will be strucutured
+        from and unstructured to src_key. Useful for properties in the unstructured data
+        (json) that are python keywords.
+
+        """
         metadata = dict() if not metadata else metadata
         if src_key:
             metadata[CATTRS_METADATA_KEY] = src_key

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -443,7 +443,8 @@ class Converter(object):
         return create_uniq_field_dis_func(*union_types)
 
     def ib(self, default=attr.NOTHING, validator=None, repr=True, cmp=True,
-           hash=None, init=True, convert=None, metadata={}, src_key=None):
+           hash=None, init=True, convert=None, metadata=None, type=None,
+           converter=None, factory=None, kw_only=False, src_key=None):
         """Custom verion of attr.ib with extra parameter src_key.
 
         src_key will be stored in the attr metadata. The property will be strucutured
@@ -454,5 +455,7 @@ class Converter(object):
         metadata = dict() if not metadata else metadata
         if src_key:
             metadata[CATTRS_METADATA_KEY] = src_key
-        return attr.ib(default, validator, repr, cmp, hash,
-                       init, convert, metadata)
+        return attr.ib(default=default, validator=validator, repr=repr,
+                       cmp=cmp, hash=hash, init=init, convert=convert,
+                       metadata=metadata, type=type, converter=converter,
+                       factory=factory, kw_only=kw_only)

--- a/tests/test_keyword.py
+++ b/tests/test_keyword.py
@@ -2,12 +2,13 @@ import attr
 import cattr
 
 
-@attr.s(auto_attribs=True)
-class Test:
-    renamed: str = cattr.ib(src_key='class')
+@attr.s
+class MyClass(object):
+    renamed = cattr.ib(src_key='class', type=str)
 
 
 def test_structure_keywords():
+
     data = {'class': 'value'}
-    obj = cattr.structure(data, Test)
+    obj = cattr.structure(data, MyClass)
     assert cattr.unstructure(obj) == data

--- a/tests/test_keyword.py
+++ b/tests/test_keyword.py
@@ -1,0 +1,13 @@
+import attr
+import cattr
+
+
+@attr.s(auto_attribs=True)
+class Test:
+    renamed: str = cattr.ib(src_key='class')
+
+
+def test_structure_keywords():
+    data = {'class': 'value'}
+    obj = cattr.structure(data, Test)
+    assert cattr.unstructure(obj) == data


### PR DESCRIPTION
There are scenarios where the unstructured data have properties that are forbidden keywords in python. In an `attrs` class this property needs to take a different name.

Example data: `{'class': 'not allowed'}`

The following `attrs` class is **invalid** - at least I wouldn't see how that can be made working in `attrs` nor `cattr`:

```python
@attr.s
class MyClass(object):
    class = cattr.ib(type=str)
```

Proposal: use `attrs` metadata and provide an extension to `cattr` that allows to remap the invalid name to something valid when structuring and vice-versa when unstructuring.

I added a test, - but the `hypothesis` business is beyond my skills - sorry.

This works for me and is a solution similar to that taken by other packages (e.g. `related`):

```python
import attr
import cattr


@attr.s
class MyClass(object):
    renamed = cattr.ib(src_key='class', type=str)


def test_structure_keywords():
    data = {'class': 'value'}
    obj = cattr.structure(data, MyClass)
    assert cattr.unstructure(obj) == data
```