### PR TITLE
Fix hypothesis `choices` removal

### DIFF
--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -32,7 +32,6 @@ from hypothesis.strategies import (
     frozensets,
     just,
     binary,
-    choices,
     data,
 )
 
@@ -331,11 +330,11 @@ def test_structure_hook_func(converter):
         converter.structure(10, Bar)
 
 
-@given(choices(), enums_of_primitives())
-def test_structuring_enums(converter, choice, enum):
+@given(data(), enums_of_primitives())
+def test_structuring_enums(converter, data, enum):
     # type: (Converter, Any, Any) -> None
     """Test structuring enums by their values."""
-    val = choice(list(enum))
+    val = data.draw(sampled_from(list(enum)))
 
     assert converter.structure(val.value, enum) == val
 

--- a/tests/test_unstructure.py
+++ b/tests/test_unstructure.py
@@ -12,7 +12,7 @@ from cattr.converters import Converter, UnstructureStrategy
 
 from attr import asdict, astuple
 from hypothesis import given
-from hypothesis.strategies import sampled_from, choices
+from hypothesis.strategies import sampled_from, data
 
 unstruct_strats = sampled_from(
     [UnstructureStrategy.AS_DICT, UnstructureStrategy.AS_TUPLE]
@@ -61,13 +61,13 @@ def test_mapping_unstructure(map_and_type, dump_strat):
     assert type(dumped) is type(mapping)
 
 
-@given(enums_of_primitives(), unstruct_strats, choices())
-def test_enum_unstructure(enum, dump_strat, choice):
+@given(enums_of_primitives(), unstruct_strats, data())
+def test_enum_unstructure(enum, dump_strat, data):
     # type: (EnumMeta, UnstructureStrategy) -> None
     """Dumping enums of primitives converts them to their primitives."""
     converter = Converter(unstruct_strat=dump_strat)
 
-    member = choice(list(enum.__members__.values()))
+    member = data.draw(sampled_from(list(enum.__members__.values())))
 
     assert converter.unstructure(member) == member.value
 


### PR DESCRIPTION
`hypothesis.strategies.choices` was deprecated in `v3.15.0` and removed in `v4.0.0`, see the [changelog](https://hypothesis.readthedocs.io/en/latest/changes.html#v4-0-0). This PR fixes the failing tests suite.

Please verify that I've done this correctly, I've never used `hypothesis` before.