### PR TITLE
Fix master build

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -68,7 +68,7 @@ Ready to contribute? Here's how to set up `cattrs` for local development.
 
     $ mkvirtualenv cattrs
     $ cd cattrs/
-    $ pip install -e .
+    $ pip install -e .\[dev\]
 
 4. Create a branch for local development::
 

--- a/docs/structuring.rst
+++ b/docs/structuring.rst
@@ -155,7 +155,7 @@ These generic types are composable with all other converters.
 .. doctest::
 
     >>> cattr.structure([[1, 2], [3, 4]], Set[FrozenSet[str]])
-    {frozenset({'4', '3'}), frozenset({'1', '2'})}
+    {frozenset({'1', '2'}), frozenset({'4', '3'})}
 
 Dictionaries
 ~~~~~~~~~~~~

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -96,7 +96,11 @@ else:
         return issubclass(type, MutableSet)
 
     def is_sequence(type):
-        return issubclass(type, Sequence)
+        if is_py2:
+            is_string = issubclass(type, basestring)
+        else:
+            is_string = issubclass(type, str)
+        return issubclass(type, Sequence) and not is_string
 
     def is_tuple(type):
         return issubclass(type, Tuple)

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -97,7 +97,7 @@ else:
 
     def is_sequence(type):
         if is_py2:
-            is_string = issubclass(type, basestring)
+            is_string = issubclass(type, basestring)  # noqa:F821
         else:
             is_string = issubclass(type, str)
         return issubclass(type, Sequence) and not is_string

--- a/src/cattr/generation.py
+++ b/src/cattr/generation.py
@@ -21,7 +21,7 @@ _neutral = AttributeOverride()
 
 
 def make_dict_unstructure_fn(cl, converter, **kwargs):
-    # type: (Type[T], Converter, **AttributeOverride) -> Callable[[T], Dict[str, Any]]
+    # type: (Type[T], Converter, **AttributeOverride) -> Callable[[T], Dict[str, Any]]  # noqa:E501
     """Generate a specialized dict unstructuring function for a class."""
     cl_name = cl.__name__
     fn_name = "unstructure_" + cl_name

--- a/src/cattr/generation.py
+++ b/src/cattr/generation.py
@@ -1,7 +1,8 @@
-from typing import Any, Callable, Dict, Type, TypeVar
+from typing import Any, Callable, Dict, Sequence, Type, TypeVar
 
 import attr
 
+from ._compat import is_sequence
 from cattr.converters import Converter
 
 T = TypeVar("T")
@@ -81,6 +82,8 @@ def make_dict_unstructure_fn(cl, converter, **kwargs):
         else:
             # Do the dispatch here and now.
             type = a.type
+            if is_sequence(type):
+                type = Sequence
             conv_function = converter._unstructure_func.dispatch(type)
             if d is not attr.NOTHING and override.omit_if_default:
                 def_name = "__cattr_def_{}".format(attr_name)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,7 +24,7 @@ from attr import make_class, NOTHING
 from hypothesis import strategies as st, settings, HealthCheck
 
 settings.register_profile(
-    "CI", settings(suppress_health_check=[HealthCheck.too_slow])
+    "CI", settings(suppress_health_check=[HealthCheck.too_slow]), deadline=None
 )
 
 if "CI" in os.environ:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ def converter():
 
 
 settings.register_profile(
-    "tests", suppress_health_check=(HealthCheck.too_slow,)
+    "tests", suppress_health_check=(HealthCheck.too_slow,), deadline=None
 )
 
 settings.load_profile("tests")


### PR DESCRIPTION
Fix test_unmodified_generated_unstructuring test

 This was broken for 3.7 due to how `cattr.generation.make_dict_unstructure_fn`
reaches directly into `converter._unstructure_func.dispatch` to get the
converter function passing the annotated type of the field. In 3.7 the
`TypeError: Subscripted generics cannot be used with class and instance checks`
issue causes the `dispatch` to be the fallback identity converter func.

Normal usage (i.e. unstructure_attrs_asdict) passes in field_inst.__class__
which would never hit the above `TypeError` so this issue is unique to
`make_dict_unstructure_fn`