### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ matrix:
       env: TOXENV=py37
       dist: xenial
       sudo: true
+    - python: "3.8"
+      env: TOXENV=py38
+      dist: xenial
+      sudo: true
 
     # Meta
     - python: "3.6"

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -12,7 +12,7 @@ from typing import (
 version_info = sys.version_info[0:3]
 is_py2 = version_info[0] == 2
 is_py3 = version_info[0] == 3
-is_py37 = version_info[:2] == (3, 7)
+is_py37_or_higher = version_info[0] == 3 and version_info[1] >= 7
 
 if is_py2:
     from functools32 import lru_cache
@@ -26,7 +26,7 @@ else:
     unicode = str
     bytes = bytes
 
-if is_py37:
+if is_py37_or_higher:
     from typing import List, Union, _GenericAlias
 
     def is_union_type(obj):

--- a/tests/_compat.py
+++ b/tests/_compat.py
@@ -1,6 +1,6 @@
-from cattr._compat import is_py37, is_bare
+from cattr._compat import is_py37_or_higher, is_bare
 
-if is_py37:
+if is_py37_or_higher:
 
     def change_type_param(cl, new_params):
         if is_bare(cl):


### PR DESCRIPTION
Actually we validate only 3.7 version

It seems, that we should validate versions that are equal or higher then 3.7

Closes #71 