### PR TITLE
py3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ matrix:
       env: TOXENV=py37
       dist: xenial
       sudo: true
+    - python: "3.8"
+      env: TOXENV=py38
+      dist: xenial
+      sudo: true
 
     # Meta
     - python: "3.6"

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -12,7 +12,7 @@ from typing import (
 version_info = sys.version_info[0:3]
 is_py2 = version_info[0] == 2
 is_py3 = version_info[0] == 3
-is_py37 = version_info[:2] == (3, 7)
+is_py37_or_newer = version_info[:2] >= (3, 7)
 
 if is_py2:
     from functools32 import lru_cache
@@ -26,7 +26,7 @@ else:
     unicode = str
     bytes = bytes
 
-if is_py37:
+if is_py37_or_newer:
     from typing import List, Union, _GenericAlias
 
     def is_union_type(obj):

--- a/tests/_compat.py
+++ b/tests/_compat.py
@@ -1,6 +1,6 @@
-from cattr._compat import is_py37, is_bare
+from cattr._compat import is_py37_or_newer, is_bare
 
-if is_py37:
+if is_py37_or_newer:
 
     def change_type_param(cl, new_params):
         if is_bare(cl):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, pypy, py35, pypy3, py36, py37, lint
+envlist = py27, pypy, py35, pypy3, py36, py37, py38, lint
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
Hey, thanks for great work!

`>=` checking for 3.7 seems more reasonable than strict `==`

cattrs fail to import on py3.8 otherwise