### PR TITLE
Add Python 3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       env: TOXENV=py38
       dist: xenial
       sudo: true
-    - python: "3.9"
+    - python: "3.9-dev"
       env: TOXENV=py39
       dist: xenial
       sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     # Meta
     - python: "3.8"
       env: TOXENV=lint
-    - python: "3.6"
+    - python: "3.8"
       env: TOXENV=docs
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
       env: TOXENV=py38
       dist: xenial
       sudo: true
+    - python: "3.9"
+      env: TOXENV=py39
+      dist: xenial
+      sudo: true
 
     # Meta
     - python: "3.8"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 1.1.0 (UNRELEASED)
 ------------------
 * Python 2 support removal. If you need it, use a version below 1.1.0.
+* Python 3.9 support added.
 
 1.0.0 (2019-12-27)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,6 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -11,14 +11,12 @@ from typing import (
 )
 
 version_info = sys.version_info[0:3]
-is_py37 = version_info[:2] == (3, 7)
-is_py38 = version_info[:2] == (3, 8)
-is_py39 = version_info[:2] == (3, 9)
+is_py36 = version_info[:2] == (3, 6)
 
 unicode = str
 bytes = bytes
 
-if is_py37 or is_py38 or is_py39:
+if not is_py36:
     from typing import List, Union, _GenericAlias
 
     def is_union_type(obj):

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -13,12 +13,12 @@ from typing import (
 version_info = sys.version_info[0:3]
 is_py37 = version_info[:2] == (3, 7)
 is_py38 = version_info[:2] == (3, 8)
-
+is_py39 = version_info[:2] == (3, 9)
 
 unicode = str
 bytes = bytes
 
-if is_py37 or is_py38:
+if is_py37 or is_py38 or is_py39:
     from typing import List, Union, _GenericAlias
 
     def is_union_type(obj):

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -86,6 +86,7 @@ if not is_py36:
         else:
             return type_
 
+
 else:
     from typing import _Union
 

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -11,7 +11,7 @@ from typing import (  # noqa: F401, imported for Mypy.
     Tuple,
     Type,
     TypeVar,
-    Union
+    Union,
 )
 
 from ._compat import (
@@ -25,7 +25,7 @@ from ._compat import (
     is_union_type,
     lru_cache,
     unicode,
-    get_type
+    get_type,
 )
 
 from .disambiguators import create_uniq_field_dis_func

--- a/tests/_compat.py
+++ b/tests/_compat.py
@@ -1,15 +1,11 @@
-from cattr._compat import is_py37, is_py38, is_bare
+from cattr._compat import is_py36, is_bare
 
-if is_py37 or is_py38:
-
+if is_py36:
+    def change_type_param(cl, new_params):
+        cl.__args__ = (new_params,)
+        return cl
+else:
     def change_type_param(cl, new_params):
         if is_bare(cl):
             return cl[new_params]
         return cl.copy_with(new_params)
-
-
-else:
-
-    def change_type_param(cl, new_params):
-        cl.__args__ = (new_params,)
-        return cl

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 
 from hypothesis import HealthCheck, settings
@@ -15,3 +16,9 @@ settings.register_profile(
 )
 
 settings.load_profile("tests")
+
+collect_ignore = []
+
+if sys.version_info[:2] < (3, 7):
+    # PEP563 only exists for python 3.7 and later
+    collect_ignore.append("test_563.py")

--- a/tests/pep563_examples/compound.py
+++ b/tests/pep563_examples/compound.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+from typing import List, Dict, Optional
+
+import attr
+
+from .point import Point
+from .region import Region
+
+# It is not clear to me how create hypothesis tests that create random input
+# files, so I have manually created a few test cases here.
+#
+# These classes are used to test whether compound types can resolve properly:
+#   'List[int]' -> typing.List[int]
+#   'Dict[str, Point]' -> typing.Dict[str, point.Point]
+#   'Optional[List[int]' -> typing.Union[typing.List[int], NoneType]
+
+
+@attr.s(auto_attribs=True)
+class HasListOfInts:
+    list_of_ints: List[int] = attr.ib(factory=list)
+
+
+@attr.s(auto_attribs=True)
+class HasListOfPoints:
+    list_of_points: List[Point] = attr.ib(factory=list)
+
+
+@attr.s(auto_attribs=True)
+class HasListOfRegions:
+    list_of_regions: List[Region] = attr.ib(factory=list)
+
+
+@attr.s(auto_attribs=True)
+class HasOptionalInt:
+    optional_int: Optional[int]
+
+
+@attr.s(auto_attribs=True)
+class HasOptionalPoint:
+    optional_point: Optional[Point]
+
+
+@attr.s(auto_attribs=True)
+class HasOptionalRegion:
+    optional_region: Optional[Region]
+
+
+@attr.s(auto_attribs=True)
+class HasOptionalListOfInts:
+    optional_list_of_ints: Optional[List[int]]
+
+
+@attr.s(auto_attribs=True)
+class HasOptionalListOfPoints:
+    optional_list_of_points: Optional[List[Point]]
+
+
+@attr.s(auto_attribs=True)
+class HasOptionalListOfRegions:
+    optional_list_of_regions: Optional[List[Region]]
+
+
+@attr.s(auto_attribs=True)
+class HasDictOfInts:
+    dict_of_ints: Dict[str, int] = attr.ib(factory=dict)
+
+
+@attr.s(auto_attribs=True)
+class HasDictOfPoints:
+    dict_of_points: Dict[str, Point] = attr.ib(factory=dict)
+
+
+@attr.s(auto_attribs=True)
+class HasDictOfRegions:
+    dict_of_regions: Dict[str, Region] = attr.ib(factory=dict)

--- a/tests/pep563_examples/point.py
+++ b/tests/pep563_examples/point.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+import attr
+
+
+@attr.s(auto_attribs=True, slots=True)
+class Point:
+    x: int
+    y: int

--- a/tests/pep563_examples/region.py
+++ b/tests/pep563_examples/region.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+import attr
+
+from .point import Point
+
+
+class RegionError(RuntimeError):
+    pass
+
+
+@attr.s(auto_attribs=True, slots=True, init=False)
+class Region:
+    topLeft: Point
+    bottomRight: Point
+
+    def __init__(self, topLeft: Point, bottomRight: Point) -> None:
+        if not topLeft < bottomRight:
+            raise RegionError("topLeft must be less than bottomRight")
+
+        self.topLeft = topLeft
+        self.bottomRight = bottomRight

--- a/tests/pep563_examples/roi.py
+++ b/tests/pep563_examples/roi.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+import attr
+
+from .region import Region
+
+
+@attr.s(auto_attribs=True, slots=True)
+class Roi:
+    region1: Region
+    region2: Region

--- a/tests/test_563.py
+++ b/tests/test_563.py
@@ -1,0 +1,50 @@
+from cattr.converters import Converter
+from hypothesis import given
+import hypothesis.strategies as st
+
+from .pep563_examples import point, region, roi
+
+
+@given(st.integers(), st.integers())
+def test_annotated_point(x, y):
+    # type: (int, int) -> None
+    converter = Converter()
+    test_point = point.Point(x, y)
+    dumped = converter.unstructure(test_point)
+    loaded = converter.structure(dumped, point.Point)
+
+    assert test_point == loaded
+
+
+def test_annotated_region():
+    # type: () -> None
+    converter = Converter()
+    test_region = region.Region(point.Point(0, 0), point.Point(100, 200))
+    dumped = converter.unstructure(test_region)
+    loaded = converter.structure(dumped, region.Region)
+
+    assert test_region == loaded
+    assert type(loaded.topLeft) is point.Point
+    assert type(loaded.bottomRight) is point.Point
+
+
+def test_annotated_roi():
+    # type: () -> None
+    converter = Converter()
+
+    test_roi = roi.Roi(
+        region.Region(point.Point(0, 0), point.Point(100, 200)),
+        region.Region(point.Point(0, 210), point.Point(100, 390)))
+
+    dumped = converter.unstructure(test_roi)
+    loaded = converter.structure(dumped, roi.Roi)
+
+    assert test_roi == loaded
+    assert type(loaded.region1) is region.Region
+    assert type(loaded.region2) is region.Region
+
+    assert type(loaded.region1.topLeft) is point.Point
+    assert type(loaded.region1.bottomRight) is point.Point
+
+    assert type(loaded.region2.topLeft) is point.Point
+    assert type(loaded.region2.bottomRight) is point.Point

--- a/tests/test_563.py
+++ b/tests/test_563.py
@@ -1,4 +1,3 @@
-import typing
 from typing import Tuple, Optional, List, Dict
 from cattr.converters import Converter
 from hypothesis import given
@@ -29,15 +28,13 @@ def MakeRegion(values: RegionInput) -> region.Region:
     x, y = point_values
     offset_x, offset_y = offset_values
     return region.Region(
-        MakePoint(point_values),
-        MakePoint((x + offset_x, y + offset_y)))
+        MakePoint(point_values), MakePoint((x + offset_x, y + offset_y))
+    )
 
 
 def MakeRoi(values: RoiInput) -> roi.Roi:
     region_1_values, region_2_values = values
-    return roi.Roi(
-        MakeRegion(region_1_values),
-        MakeRegion(region_2_values))
+    return roi.Roi(MakeRegion(region_1_values), MakeRegion(region_2_values))
 
 
 def MakeOptionalPoint(values: Optional[PointInput]) -> Optional[point.Point]:
@@ -47,8 +44,9 @@ def MakeOptionalPoint(values: Optional[PointInput]) -> Optional[point.Point]:
     return MakePoint(values)
 
 
-def MakeOptionalRegion(values: Optional[RegionInput]) \
-        -> Optional[region.Region]:
+def MakeOptionalRegion(
+    values: Optional[RegionInput],
+) -> Optional[region.Region]:
 
     if values is None:
         return None

--- a/tests/test_563.py
+++ b/tests/test_563.py
@@ -1,25 +1,82 @@
+import typing
+from typing import Tuple, Optional, List, Dict
 from cattr.converters import Converter
 from hypothesis import given
 import hypothesis.strategies as st
 
-from .pep563_examples import point, region, roi
+from .pep563_examples import point, region, roi, compound
+
+point_strategy = st.tuples(st.integers(min_value=0), st.integers(min_value=0))
+
+# Regions are constructed from two points. The second point must be greater
+# than the first
+offset_strategy = st.tuples(st.integers(min_value=1), st.integers(min_value=1))
+region_strategy = st.tuples(point_strategy, offset_strategy)
+roi_strategy = st.tuples(region_strategy, region_strategy)
+
+PointInput = Tuple[int, int]
+RegionInput = Tuple[PointInput, PointInput]
+RoiInput = Tuple[RegionInput, RegionInput]
 
 
-@given(st.integers(), st.integers())
-def test_annotated_point(x, y):
-    # type: (int, int) -> None
+def MakePoint(values: PointInput) -> point.Point:
+    x, y = values
+    return point.Point(x, y)
+
+
+def MakeRegion(values: RegionInput) -> region.Region:
+    point_values, offset_values = values
+    x, y = point_values
+    offset_x, offset_y = offset_values
+    return region.Region(
+        MakePoint(point_values),
+        MakePoint((x + offset_x, y + offset_y)))
+
+
+def MakeRoi(values: RoiInput) -> roi.Roi:
+    region_1_values, region_2_values = values
+    return roi.Roi(
+        MakeRegion(region_1_values),
+        MakeRegion(region_2_values))
+
+
+def MakeOptionalPoint(values: Optional[PointInput]) -> Optional[point.Point]:
+    if values is None:
+        return None
+
+    return MakePoint(values)
+
+
+def MakeOptionalRegion(values: Optional[RegionInput]) \
+        -> Optional[region.Region]:
+
+    if values is None:
+        return None
+
+    return MakeRegion(values)
+
+
+def MakeOptionalRoi(values: Optional[RoiInput]) -> Optional[roi.Roi]:
+    if values is None:
+        return None
+
+    return MakeRoi(values)
+
+
+@given(point_strategy)
+def test_annotated_point(values: PointInput) -> None:
     converter = Converter()
-    test_point = point.Point(x, y)
+    test_point = MakePoint(values)
     dumped = converter.unstructure(test_point)
     loaded = converter.structure(dumped, point.Point)
 
     assert test_point == loaded
 
 
-def test_annotated_region():
-    # type: () -> None
+@given(region_strategy)
+def test_annotated_region(values: RegionInput) -> None:
     converter = Converter()
-    test_region = region.Region(point.Point(0, 0), point.Point(100, 200))
+    test_region = MakeRegion(values)
     dumped = converter.unstructure(test_region)
     loaded = converter.structure(dumped, region.Region)
 
@@ -28,14 +85,11 @@ def test_annotated_region():
     assert type(loaded.bottomRight) is point.Point
 
 
-def test_annotated_roi():
+@given(roi_strategy)
+def test_annotated_roi(values: RoiInput) -> None:
     # type: () -> None
     converter = Converter()
-
-    test_roi = roi.Roi(
-        region.Region(point.Point(0, 0), point.Point(100, 200)),
-        region.Region(point.Point(0, 210), point.Point(100, 390)))
-
+    test_roi = MakeRoi(values)
     dumped = converter.unstructure(test_roi)
     loaded = converter.structure(dumped, roi.Roi)
 
@@ -48,3 +102,216 @@ def test_annotated_roi():
 
     assert type(loaded.region2.topLeft) is point.Point
     assert type(loaded.region2.bottomRight) is point.Point
+
+
+@given(st.lists(st.integers()))
+def test_list_of_ints(list_of_ints: List[int]) -> None:
+    converter = Converter()
+    p = compound.HasListOfInts(list_of_ints)
+    dumped = converter.unstructure(p)
+    loaded = converter.structure(dumped, compound.HasListOfInts)
+    assert p == loaded
+    assert type(loaded.list_of_ints) is list
+
+
+@given(st.lists(point_strategy))
+def test_list_of_points(values: List[PointInput]) -> None:
+    converter = Converter()
+    p = compound.HasListOfPoints([MakePoint(i) for i in values])
+    dumped = converter.unstructure(p)
+    loaded = converter.structure(dumped, compound.HasListOfPoints)
+
+    assert p == loaded
+    assert type(loaded.list_of_points) is list
+
+    if len(values):
+        assert type(loaded.list_of_points[0]) is point.Point
+
+
+@given(st.lists(region_strategy))
+def test_list_of_regions(values: List[RegionInput]) -> None:
+    converter = Converter()
+    p = compound.HasListOfRegions([MakeRegion(i) for i in values])
+    dumped = converter.unstructure(p)
+    loaded = converter.structure(dumped, compound.HasListOfRegions)
+
+    assert p == loaded
+    assert type(loaded.list_of_regions) is list
+
+    if len(values):
+        first_region = loaded.list_of_regions[0]
+        assert type(first_region) is region.Region
+        assert type(first_region.topLeft) is point.Point
+
+
+@given(st.integers() | st.none())
+def test_optional_int(value: Optional[int]) -> None:
+    converter = Converter()
+    p = compound.HasOptionalInt(value)
+    dumped = converter.unstructure(p)
+    loaded = converter.structure(dumped, compound.HasOptionalInt)
+
+    assert p == loaded
+
+    if loaded.optional_int is None:
+        assert value is None
+        return
+
+    assert type(loaded.optional_int) is int
+
+
+@given(point_strategy | st.none())
+def test_optional_point(values: Optional[PointInput]) -> None:
+    converter = Converter()
+    p = compound.HasOptionalPoint(MakeOptionalPoint(values))
+    dumped = converter.unstructure(p)
+    loaded = converter.structure(dumped, compound.HasOptionalPoint)
+
+    assert p == loaded
+
+    if loaded.optional_point is None:
+        assert values is None
+        return
+
+    assert type(loaded.optional_point) is point.Point
+    assert type(loaded.optional_point.x) is int
+
+
+@given(region_strategy | st.none())
+def test_optional_region(values: Optional[RegionInput]) -> None:
+    converter = Converter()
+    p = compound.HasOptionalRegion(MakeOptionalRegion(values))
+    dumped = converter.unstructure(p)
+    loaded = converter.structure(dumped, compound.HasOptionalRegion)
+
+    assert p == loaded
+
+    if loaded.optional_region is None:
+        assert values is None
+        return
+
+    assert type(loaded.optional_region) is region.Region
+    assert type(loaded.optional_region.topLeft) is point.Point
+
+
+@given(st.lists(st.integers()) | st.none())
+def test_optional_list_of_ints(values: Optional[List[int]]) -> None:
+    converter = Converter()
+    p = compound.HasOptionalListOfInts(values)
+    dumped = converter.unstructure(p)
+    loaded = converter.structure(dumped, compound.HasOptionalListOfInts)
+
+    assert p == loaded
+
+    if loaded.optional_list_of_ints is None:
+        assert values is None
+        return
+
+    assert type(loaded.optional_list_of_ints) is list
+
+    if len(loaded.optional_list_of_ints):
+        assert type(loaded.optional_list_of_ints[0]) is int
+
+
+@given(st.lists(point_strategy) | st.none())
+def test_optional_list_of_points(values: Optional[List[PointInput]]) -> None:
+    converter = Converter()
+
+    inputValue: Optional[List[point.Point]] = None
+
+    if values is not None:
+        inputValue = [MakePoint(i) for i in values]
+
+    p = compound.HasOptionalListOfPoints(inputValue)
+    dumped = converter.unstructure(p)
+    loaded = converter.structure(dumped, compound.HasOptionalListOfPoints)
+
+    assert p == loaded
+
+    if loaded.optional_list_of_points is None:
+        assert values is None
+        return
+
+    assert type(loaded.optional_list_of_points) is list
+
+    if len(loaded.optional_list_of_points):
+        assert type(loaded.optional_list_of_points[0]) is point.Point
+
+
+@given(st.lists(region_strategy) | st.none())
+def test_optional_list_of_regions(values: Optional[List[RegionInput]]) -> None:
+    converter = Converter()
+
+    inputValue: Optional[List[region.Region]] = None
+
+    if values is not None:
+        inputValue = [MakeRegion(i) for i in values]
+
+    p = compound.HasOptionalListOfRegions(inputValue)
+    dumped = converter.unstructure(p)
+    loaded = converter.structure(dumped, compound.HasOptionalListOfRegions)
+
+    assert p == loaded
+
+    if loaded.optional_list_of_regions is None:
+        assert values is None
+        return
+
+    assert p == loaded
+
+    if loaded.optional_list_of_regions is None:
+        assert values is None
+        return
+
+    assert type(loaded.optional_list_of_regions) is list
+
+    if len(values):
+        first_region = loaded.optional_list_of_regions[0]
+        assert type(first_region) is region.Region
+        assert type(first_region.topLeft) is point.Point
+
+
+@given(st.dictionaries(st.text(), st.integers()))
+def test_dict_of_ints(values: Dict[str, int]) -> None:
+    converter = Converter()
+    p = compound.HasDictOfInts(values)
+    dumped = converter.unstructure(p)
+    loaded = converter.structure(dumped, compound.HasDictOfInts)
+
+    assert p == loaded
+    assert type(loaded.dict_of_ints) is dict
+
+    if len(loaded.dict_of_ints):
+        assert type(next(iter(loaded.dict_of_ints.values()))) is int
+
+
+@given(st.dictionaries(st.text(), point_strategy))
+def test_dict_of_points(values: Dict[str, PointInput]) -> None:
+    converter = Converter()
+    inputValue = {key: MakePoint(value) for key, value in values.items()}
+    p = compound.HasDictOfPoints(inputValue)
+    dumped = converter.unstructure(p)
+    loaded = converter.structure(dumped, compound.HasDictOfPoints)
+
+    assert p == loaded
+    assert type(loaded.dict_of_points) is dict
+
+    if len(loaded.dict_of_points):
+        assert type(next(iter(loaded.dict_of_points.values()))) is point.Point
+
+
+@given(st.dictionaries(st.text(), region_strategy))
+def test_dict_of_regions(values: Dict[str, RegionInput]) -> None:
+    converter = Converter()
+    inputValue = {key: MakeRegion(value) for key, value in values.items()}
+    p = compound.HasDictOfRegions(inputValue)
+    dumped = converter.unstructure(p)
+    loaded = converter.structure(dumped, compound.HasDictOfRegions)
+
+    assert p == loaded
+    assert type(loaded.dict_of_regions) is dict
+
+    if len(loaded.dict_of_regions):
+        any_region = next(iter(loaded.dict_of_regions.values()))
+        assert type(any_region) is region.Region
+        assert type(any_region.bottomRight) is point.Point

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,21 @@
 [tox]
-envlist = pypy3, py36, py37, py38, py39, lint
+envlist = pypy3, py36, py37, py38, py39, lint-{py36,py37}
 
-[testenv:lint]
+[testenv:lint-py36]
 skip_install = true
 basepython = python3.6
+extras = tests
+deps =
+    flake8
+    black
+commands =
+    flake8 --exclude=pep563*,test_563.py src tests setup.py conftest.py docs/conf.py
+    black --exclude=pep563*,test_563.py --check --verbose setup.py src tests docs/conf.py
+
+[testenv:lint-py37]
+skip_install = true
+basepython = 
+    py37: python3.7
 extras = tests
 deps =
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, pypy3, py36, py37, py38, py39, lint
+envlist = pypy3, py36, py37, py38, py39, lint
 
 [testenv:lint]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, pypy3, py36, py37, py38, lint
+envlist = py35, pypy3, py36, py37, py38, py39, lint
 
 [testenv:lint]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -10,12 +10,11 @@ deps =
     black
 commands =
     flake8 --exclude=pep563*,test_563.py src tests setup.py conftest.py docs/conf.py
-    black --exclude=pep563*,test_563.py --check --verbose setup.py src tests docs/conf.py
+    black --exclude="pep563*|test_563.py" --check --verbose setup.py src tests docs/conf.py
 
 [testenv:lint-py37]
 skip_install = true
-basepython = 
-    py37: python3.7
+basepython = python3.7
 extras = tests
 deps =
     flake8
@@ -27,6 +26,7 @@ commands =
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/cattr
+whitelist_externals = coverage
 extras = dev
 commands =
     pip install -U pip


### PR DESCRIPTION
This is similar to the PR that added Python3.8 support in https://github.com/Tinche/cattrs/pull/73

I've cleaned up the logic somewhat as now the only outlier is python3.6 - so this is the only version we check for.

I've also added `tox` and `travis` config for Python 3.9.

Happy to change anything if required.

## Other Information

I have a `Pipfile` & `Pipfile.lock` locally as I had to install `pytest` & `hypothesis`. Is this something you would like added to the project? Possibly using a `requirements.txt`?