### PR TITLE
Set Explicit requirement for Python>=3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     license="MIT license",
     zip_safe=False,
     keywords="cattrs",
-    python_requires='~=3.7',
+    python_requires="~=3.7",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     license="MIT license",
     zip_safe=False,
     keywords="cattrs",
+    python_requires='~=3.7',
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Check https://packaging.python.org/guides/dropping-older-python-versions/ for more details

The latest cattrs 1.1.0 removed support for Python 3.6 but it since most of the libraries like Airflow (I am the maintainer and PMC Member of the Airflow Project) have an open bound for cattrs in the dependency, new users trying to setup airflow breaks (Issue: https://github.com/apache/airflow/issues/11965).

Setting an explicit `python_requires` means Python 3.6 users won't be able to download the new cattrs version and fallback to the older version that supports Python 3.6 and hence it will work without breaking Airflow too.

Thanks for creating and maintaining this library, appreciate all your effort, hope this PR is useful