### PR TITLE
Fix signature for generic structure hooks

### DIFF
--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -169,7 +169,7 @@ class Converter(object):
         self._unstructure_func.register_func_list([(check_func, func)])
 
     def register_structure_hook(
-        self, cl: Type[T], func: Callable[[Any, Type[V]], T]
+        self, cl: Type[T], func: Callable[[Any, Type[T]], T]
     ):
         """Register a primitive-to-class converter function for a type.
 
@@ -188,7 +188,7 @@ class Converter(object):
     def register_structure_hook_func(
         self,
         check_func: Callable[[Type[T]], bool],
-        func: Callable[[Any, Type[V]], T],
+        func: Callable[[Any, Type[T]], T],
     ):
         """Register a class-to-primitive converter function for a class, using
         a function to check if it's a match.


### PR DESCRIPTION
A generic structure hook is expected to return a value of the type that it accepts as an argument.

I feel guilty submitting a two-byte PR but I noticed that there aren't any tests that invoke mypy. Would it be useful to do some type checking as part of the test suite?

Closes #106.