### PR TITLE
fix structure for union of attr classes with default values

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+1.1.2 (unrelased)
+-----------------
+* Disambigualation do not pick non required field.
+  (`#108 <https://github.com/Tinche/cattrs/pull/108>`_)
+
 1.1.1 (2020-10-30)
 ------------------
 * Add metadata for supported Python versions.

--- a/src/cattr/disambiguators.py
+++ b/src/cattr/disambiguators.py
@@ -22,7 +22,8 @@ def create_uniq_field_dis_func(*classes: Type) -> Callable:
     if len(classes) < 2:
         raise ValueError("At least two classes required.")
     cls_and_attrs = [
-        (cl, set(at.name for at in fields(get_origin(cl) or cl))) for cl in classes
+        (cl, set(at.name for at in fields(get_origin(cl) or cl)))
+        for cl in classes
     ]
     if len([attrs for _, attrs in cls_and_attrs if len(attrs) == 0]) > 1:
         raise ValueError("At least two classes have no attributes.")

--- a/src/cattr/disambiguators.py
+++ b/src/cattr/disambiguators.py
@@ -49,7 +49,14 @@ def create_uniq_field_dis_func(*classes: Type) -> Callable:
             if not uniq:
                 m = "{} has no usable unique attributes.".format(cl)
                 raise ValueError(m)
-            uniq_attrs_dict[next(iter(uniq))] = cl
+            # We need a unique attribute with no default.
+            cl_fields = fields(get_origin(cl) or cl)
+            for attr_name in uniq:
+                if getattr(cl_fields, attr_name).default is NOTHING:
+                    break
+            else:
+                raise Exception(f"{cl} has no usable non-default attributes.")
+            uniq_attrs_dict[attr_name] = cl
         else:
             fallback = cl
 

--- a/src/cattr/disambiguators.py
+++ b/src/cattr/disambiguators.py
@@ -22,15 +22,7 @@ def create_uniq_field_dis_func(*classes: Type) -> Callable:
     if len(classes) < 2:
         raise ValueError("At least two classes required.")
     cls_and_attrs = [
-        (
-            cl,
-            set(
-                at.name
-                for at in fields(get_origin(cl) or cl)
-                if at.default is NOTHING
-            ),
-        )
-        for cl in classes
+        (cl, set(at.name for at in fields(get_origin(cl) or cl))) for cl in classes
     ]
     if len([attrs for _, attrs in cls_and_attrs if len(attrs) == 0]) > 1:
         raise ValueError("At least two classes have no attributes.")

--- a/src/cattr/disambiguators.py
+++ b/src/cattr/disambiguators.py
@@ -10,7 +10,7 @@ from typing import (  # noqa: F401, imported for Mypy.
     Type,
 )
 
-from attr import fields
+from attr import fields, NOTHING
 
 from cattr._compat import get_origin
 
@@ -22,7 +22,14 @@ def create_uniq_field_dis_func(*classes: Type) -> Callable:
     if len(classes) < 2:
         raise ValueError("At least two classes required.")
     cls_and_attrs = [
-        (cl, set(at.name for at in fields(get_origin(cl) or cl)))
+        (
+            cl,
+            set(
+                at.name
+                for at in fields(get_origin(cl) or cl)
+                if at.default is NOTHING
+            ),
+        )
         for cl in classes
     ]
     if len([attrs for _, attrs in cls_and_attrs if len(attrs) == 0]) > 1:

--- a/src/cattr/disambiguators.py
+++ b/src/cattr/disambiguators.py
@@ -48,7 +48,7 @@ def create_uniq_field_dis_func(*classes: Type) -> Callable:
                 if getattr(cl_fields, attr_name).default is NOTHING:
                     break
             else:
-                raise Exception(f"{cl} has no usable non-default attributes.")
+                raise ValueError(f"{cl} has no usable non-default attributes.")
             uniq_attrs_dict[attr_name] = cl
         else:
             fallback = cl

--- a/tests/test_disambigutors.py
+++ b/tests/test_disambigutors.py
@@ -1,4 +1,6 @@
 """Tests for auto-disambiguators."""
+from typing import Any
+
 import attr
 import pytest
 
@@ -40,6 +42,18 @@ def test_edge_errors():
     with pytest.raises(ValueError):
         # No unique fields on either class.
         create_uniq_field_dis_func(C, D)
+
+    @attr.s
+    class E:
+        pass
+
+    @attr.s
+    class F:
+        b = attr.ib(default=Any)
+
+    with pytest.raises(ValueError):
+        # no usable non-default attributes
+        create_uniq_field_dis_func(E, F)
 
 
 @given(simple_classes(defaults=False))

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -29,6 +29,7 @@ from hypothesis.strategies import (
 )
 from pytest import raises
 
+import attr
 from cattr import Converter
 from cattr._compat import is_bare, is_union_type
 from cattr.converters import NoneType
@@ -351,3 +352,21 @@ def test_subclass_registration_is_honored():
     converter.register_structure_hook(Bar, lambda obj, cls: cls("bar"))
     assert converter.structure(None, Foo).value == "foo"
     assert converter.structure(None, Bar).value == "bar"
+
+
+def test_structure_union_edge_case():
+    converter = Converter()
+
+    @attr.s(auto_attribs=True)
+    class A:
+        a1: Any
+        a2: Optional[Any] = None
+
+    @attr.s(auto_attribs=True)
+    class B:
+        b1: Any
+        b2: Optional[Any] = None
+
+    assert converter.structure(
+        [{"a1": "foo"}, {"b1": "bar"}], List[Union[A, B]]
+    ) == [A("foo"), B("bar")]


### PR DESCRIPTION
Structure union of attr classes when one of the fields was optional and had a default value was not deterministic.

Disambiguator function sometimes was created to use field with default value - and because it's allowed to not provide this value to `__init__` method wrong class was chosen to structure.

A provided test case is a minimal deterministic test I was able to generate. 
