### PR TITLE
Structure using the value of attr.ib converter, if defined

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,9 @@ History
 * Fix ``GenConverter`` mapping structuring for unannotated dicts on Python 3.8.
   (`#151 <https://github.com/Tinche/cattrs/issues/151>`_)
 * The source code for generated un/structuring functions is stored in the `linecache` cache, which enables more informative stack traces when un/structuring errors happen using the `GenConverter`. This behavior can optionally be disabled to save memory.
+* Support using the attr converter callback during structure. 
+  By default, this is a method of last resort, but it can be elevated to the default by setting `prefer_attrib_converters=True` on `Converter` or `GenConverter`. 
+  (`#138 <https://github.com/Tinche/cattrs/issues/138>`_)
 
 1.7.1 (2021-05-28)
 ------------------

--- a/docs/structuring.rst
+++ b/docs/structuring.rst
@@ -284,8 +284,8 @@ and their own converters work out of the box. Given a mapping ``d`` and class
 
     >>> @attr.s
     ... class A:
-    ...     a = attr.ib()
-    ...     b = attr.ib()
+    ...     a: int = attr.ib()
+    ...     b: int = attr.ib()
     ...
     >>> cattr.structure({'a': 1, 'b': '2'}, A)
     A(a=1, b=2)
@@ -298,8 +298,8 @@ Classes like these deconstructed into tuples can be structured using
 
     >>> @attr.s
     ... class A:
-    ...     a = attr.ib()
-    ...     b = attr.ib(type=int)
+    ...     a: str = attr.ib()
+    ...     b: int = attr.ib()
     ...
     >>> cattr.structure_attrs_fromtuple(['string', '2'], A)
     A(a='string', b=2)
@@ -312,8 +312,8 @@ Loading from tuples can be made the default by creating a new ``Converter`` with
     >>> converter = cattr.Converter(unstruct_strat=cattr.UnstructureStrategy.AS_TUPLE)
     >>> @attr.s
     ... class A:
-    ...     a = attr.ib()
-    ...     b = attr.ib(type=int)
+    ...     a: str = attr.ib()
+    ...     b: int = attr.ib()
     ...
     >>> converter.structure(['string', '2'], A)
     A(a='string', b=2)
@@ -337,7 +337,7 @@ attributes with ``attrib``.
     # Note: register_structure_hook has not been called, so this will fallback to 'ip_address'
     >>> @attr.s
     ... class A:
-    ...     a = attr.ib(type=IPv4Address, converter=ip_address)
+    ...     a: IPv4Address = attr.ib(converter=ip_address)
 
     >>> converter.structure({'a': '127.0.0.1'}, A)
     A(a=IPv4Address('127.0.0.1'))
@@ -353,7 +353,7 @@ can be inverted by setting ``prefer_attrib_converters`` to ``True``.
 
     >>> @attr.s
     ... class A:
-    ...     a = attr.ib(type=int, converter=lambda v: int(v) + 5)
+    ...     a: int = attr.ib(converter=lambda v: int(v) + 5)
 
     >>> converter.structure({'a': '10'}, A)
     A(a=15)
@@ -390,7 +390,7 @@ attributes holding ``attrs`` classes and dataclasses.
     ...
     >>> @attr.s
     ... class B:
-    ...     b = attr.ib(type=A)  # Legacy syntax.
+    ...     b: A = attr.ib()
     ...
     >>> cattr.structure({'b': {'a': '1'}}, B)
     B(b=A(a=1))

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -307,7 +307,7 @@ class Converter(object):
             "Unsupported type: {0}. Register a structure hook for "
             "it.".format(cl)
         )
-        raise StructureHandlerNotFoundError(msg)
+        raise StructureHandlerNotFoundError(msg, type_=cl)
 
     @staticmethod
     def _structure_call(obj, cl):
@@ -503,7 +503,8 @@ class Converter(object):
         if not all(has(get_origin(e) or e) for e in union_types):
             raise StructureHandlerNotFoundError(
                 "Only unions of attr classes supported "
-                "currently. Register a loads hook manually."
+                "currently. Register a loads hook manually.",
+                type_=union,
             )
         return create_uniq_field_dis_func(*union_types)
 

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -298,7 +298,7 @@ class Converter(object):
             return obj
 
         if is_generic(cl):
-            fn = make_dict_structure_fn(cl, self)
+            fn = make_dict_structure_fn(cl, self, _cattrs_prefer_attrib_converters=self._prefer_attrib_converters)
             self.register_structure_hook(cl, fn)
             return fn(obj)
 
@@ -682,6 +682,7 @@ class GenConverter(Converter):
             cl,
             self,
             _cattrs_forbid_extra_keys=self.forbid_extra_keys,
+            _cattrs_prefer_attrib_converters=self._prefer_attrib_converters,
             **attrib_overrides,
         )
         self._structure_func.register_cls_list([(cl, h)], direct=True)

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -298,7 +298,11 @@ class Converter(object):
             return obj
 
         if is_generic(cl):
-            fn = make_dict_structure_fn(cl, self, _cattrs_prefer_attrib_converters=self._prefer_attrib_converters)
+            fn = make_dict_structure_fn(
+                cl,
+                self,
+                _cattrs_prefer_attrib_converters=self._prefer_attrib_converters,
+            )
             self.register_structure_hook(cl, fn)
             return fn(obj)
 

--- a/src/cattr/dispatch.py
+++ b/src/cattr/dispatch.py
@@ -3,6 +3,8 @@ from typing import Any, Callable, List, Tuple, Union
 
 import attr
 
+from .errors import StructureHandlerNotFoundError
+
 
 @attr.s
 class _DispatchNotFound:
@@ -121,4 +123,6 @@ class FunctionDispatch:
                     return handler(typ)
                 else:
                     return handler
-        raise KeyError("unable to find handler for {0}".format(typ))
+        raise StructureHandlerNotFoundError(
+            "unable to find handler for {0}".format(typ)
+        )

--- a/src/cattr/dispatch.py
+++ b/src/cattr/dispatch.py
@@ -124,5 +124,5 @@ class FunctionDispatch:
                 else:
                     return handler
         raise StructureHandlerNotFoundError(
-            "unable to find handler for {0}".format(typ)
+            f"unable to find handler for {typ}", type_=typ
         )

--- a/src/cattr/errors.py
+++ b/src/cattr/errors.py
@@ -1,0 +1,2 @@
+class StructureHandlerNotFoundError(Exception):
+    pass

--- a/src/cattr/errors.py
+++ b/src/cattr/errors.py
@@ -1,2 +1,9 @@
+from typing import Type
+
+
 class StructureHandlerNotFoundError(Exception):
-    pass
+    """Error raised when structuring cannot find a handler for converting inputs into :attr:`type_`."""
+
+    def __init__(self, message: str, type_: Type) -> None:
+        super().__init__(message)
+        self.type_ = type_

--- a/src/cattr/gen.py
+++ b/src/cattr/gen.py
@@ -135,6 +135,7 @@ def make_dict_structure_fn(
     converter,
     _cattrs_forbid_extra_keys: bool = False,
     _cattrs_use_linecache: bool = True,
+    _cattrs_prefer_attrib_converters: bool = False,
     **kwargs,
 ):
     """Generate a specialized dict structuring function for an attrs class."""
@@ -187,7 +188,7 @@ def make_dict_structure_fn(
         # For each attribute, we try resolving the type here and now.
         # If a type is manually overwritten, this function should be
         # regenerated.
-        if converter._prefer_attrib_converters and a.converter is not None:
+        if _cattrs_prefer_attrib_converters and a.converter is not None:
             # The attribute has defined its own conversion, so pass
             # the original value through without invoking cattr hooks
             handler = _passthru
@@ -196,7 +197,7 @@ def make_dict_structure_fn(
         else:
             handler = converter.structure
 
-        if not converter._prefer_attrib_converters and a.converter is not None:
+        if not _cattrs_prefer_attrib_converters and a.converter is not None:
             handler = _fallback_to_passthru(handler)
 
         struct_handler_name = f"structure_{an}"

--- a/src/cattr/gen.py
+++ b/src/cattr/gen.py
@@ -3,13 +3,16 @@ import linecache
 import re
 import uuid
 from dataclasses import is_dataclass
-from typing import Any, Optional, Type, TypeVar
+from typing import Any, Optional, TYPE_CHECKING, Type, TypeVar
 
 import attr
 from attr import NOTHING, resolve_types
 
 from ._compat import adapted_fields, get_args, get_origin, is_bare, is_generic
 from .errors import StructureHandlerNotFoundError
+
+if TYPE_CHECKING:
+    from cattr.converters import Converter
 
 
 @attr.s(slots=True, frozen=True)
@@ -132,7 +135,7 @@ def generate_mapping(cl: Type, old_mapping):
 
 def make_dict_structure_fn(
     cl: Type,
-    converter,
+    converter: "Converter",
     _cattrs_forbid_extra_keys: bool = False,
     _cattrs_use_linecache: bool = True,
     _cattrs_prefer_attrib_converters: bool = False,
@@ -212,9 +215,7 @@ def make_dict_structure_fn(
                     f"    '{ian}': {struct_handler_name}(o['{kn}'], type_{an}),"
                 )
             else:
-                lines.append(
-                    f"    '{ian}': o['{kn}'],"
-                )
+                lines.append(f"    '{ian}': o['{kn}'],")
         else:
             post_lines.append(f"  if '{kn}' in o:")
             if handler:
@@ -222,9 +223,7 @@ def make_dict_structure_fn(
                     f"    res['{ian}'] = {struct_handler_name}(o['{kn}'], type_{an})"
                 )
             else:
-                post_lines.append(
-                    f"    res['{ian}'] = o['{kn}']"
-                )
+                post_lines.append(f"    res['{ian}'] = o['{kn}']")
 
     lines.append("    }")
     if _cattrs_forbid_extra_keys:

--- a/tests/test_function_dispatch.py
+++ b/tests/test_function_dispatch.py
@@ -1,12 +1,12 @@
 import pytest
 
-from cattr.dispatch import FunctionDispatch
+from cattr.dispatch import FunctionDispatch, StructureHandlerNotFoundError
 
 
 def test_function_dispatch():
     dispatch = FunctionDispatch()
 
-    with pytest.raises(KeyError):
+    with pytest.raises(StructureHandlerNotFoundError):
         dispatch.dispatch(float)
 
     test_func = object()

--- a/tests/test_function_dispatch.py
+++ b/tests/test_function_dispatch.py
@@ -6,8 +6,10 @@ from cattr.dispatch import FunctionDispatch, StructureHandlerNotFoundError
 def test_function_dispatch():
     dispatch = FunctionDispatch()
 
-    with pytest.raises(StructureHandlerNotFoundError):
+    with pytest.raises(StructureHandlerNotFoundError) as exc:
         dispatch.dispatch(float)
+
+    assert exc.value.type_ is float
 
     test_func = object()
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -4,6 +4,7 @@ import pytest
 from attr import asdict, attrs
 
 from cattr import Converter, GenConverter
+from cattr.errors import StructureHandlerNotFoundError
 
 T = TypeVar("T")
 T2 = TypeVar("T2")
@@ -79,11 +80,12 @@ def test_raises_if_no_generic_params_supplied(converter):
     data = TClass(1, "a")
 
     with pytest.raises(
-        ValueError,
+        StructureHandlerNotFoundError,
         match="Unsupported type: ~T. Register a structure hook for it.",
-    ):
+    ) as exc:
         converter.structure(asdict(data), TClass)
 
+    assert exc.value.type_ is T
 
 def test_unstructure_generic_attrs():
     c = GenConverter()

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -87,6 +87,7 @@ def test_raises_if_no_generic_params_supplied(converter):
 
     assert exc.value.type_ is T
 
+
 def test_unstructure_generic_attrs():
     c = GenConverter()
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -33,6 +33,7 @@ from pytest import raises
 from cattr import Converter
 from cattr._compat import is_bare, is_union_type
 from cattr.converters import NoneType
+from cattr.errors import StructureHandlerNotFoundError
 
 from . import (
     dicts_of_primitives,
@@ -326,9 +327,9 @@ def test_structuring_enums(data, enum):
 def test_structuring_unsupported():
     """Loading unsupported classes should throw."""
     converter = Converter()
-    with raises(ValueError):
+    with raises(StructureHandlerNotFoundError):
         converter.structure(1, Converter)
-    with raises(ValueError):
+    with raises(StructureHandlerNotFoundError):
         converter.structure(1, Union[int, str])
 
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -326,10 +326,15 @@ def test_structuring_enums(data, enum):
 def test_structuring_unsupported():
     """Loading unsupported classes should throw."""
     converter = Converter()
-    with raises(StructureHandlerNotFoundError):
+    with raises(StructureHandlerNotFoundError) as exc:
         converter.structure(1, Converter)
-    with raises(StructureHandlerNotFoundError):
+
+    assert exc.value.type_ is Converter
+    
+    with raises(StructureHandlerNotFoundError) as exc:
         converter.structure(1, Union[int, str])
+
+    assert exc.value.type_ is Union[int, str]
 
 
 def test_subclass_registration_is_honored():

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -315,6 +315,7 @@ def test_structure_hook_func():
 
     assert exc.value.type_ is Bar
 
+
 @given(data(), enums_of_primitives())
 def test_structuring_enums(data, enum):
     """Test structuring enums by their values."""
@@ -331,7 +332,7 @@ def test_structuring_unsupported():
         converter.structure(1, Converter)
 
     assert exc.value.type_ is Converter
-    
+
     with raises(StructureHandlerNotFoundError) as exc:
         converter.structure(1, Union[int, str])
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -310,9 +310,10 @@ def test_structure_hook_func():
     converter.register_structure_hook_func(can_handle, handle)
 
     assert converter.structure(10, Foo) == "hi"
-    with raises(ValueError):
+    with raises(StructureHandlerNotFoundError) as exc:
         converter.structure(10, Bar)
 
+    assert exc.value.type_ is Bar
 
 @given(data(), enums_of_primitives())
 def test_structuring_enums(data, enum):

--- a/tests/test_structure_attrs.py
+++ b/tests/test_structure_attrs.py
@@ -1,11 +1,14 @@
 """Loading of attrs classes."""
+from ipaddress import IPv4Address, IPv6Address, ip_address
 from typing import Union
+from unittest.mock import Mock
 
-from attr import NOTHING, Factory, asdict, astuple, fields
+import pytest
+from attr import NOTHING, Factory, asdict, astuple, attrib, fields, make_class
 from hypothesis import assume, given
 from hypothesis.strategies import data, lists, sampled_from
 
-from cattr.converters import Converter
+from cattr.converters import Converter, GenConverter
 
 from . import simple_classes
 
@@ -134,3 +137,69 @@ def test_structure_union_explicit(cl_and_vals_a, cl_and_vals_b):
     assert inst == converter.structure(
         converter.unstructure(inst), Union[cl_a, cl_b]
     )
+
+
+@pytest.mark.parametrize("converter_type", [Converter, GenConverter])
+def test_structure_fallback_to_attrib_converters(converter_type):
+    attrib_converter = Mock()
+    attrib_converter.side_effect = lambda val: str(val)
+
+    def called_after_default_converter(val):
+        if not isinstance(val, int):
+            raise ValueError(
+                "The 'int' conversion should have happened first by the built-in hooks"
+            )
+        return 42
+
+    converter = converter_type()
+    cl = make_class(
+        "HasConverter",
+        {
+            # non-built-in type with custom converter
+            "ip": attrib(
+                type=Union[IPv4Address, IPv6Address], converter=ip_address
+            ),
+            # attribute without type
+            "x": attrib(converter=attrib_converter),
+            # built-in types converters
+            "z": attrib(type=int, converter=called_after_default_converter),
+        },
+    )
+
+    inst = converter.structure(dict(ip="10.0.0.0", x=1, z="3"), cl)
+
+    assert inst.ip == IPv4Address("10.0.0.0")
+    assert inst.x == "1"
+    attrib_converter.assert_any_call(1)
+    assert inst.z == 42
+
+
+@pytest.mark.parametrize("converter_type", [Converter, GenConverter])
+def test_structure_prefers_attrib_converters(converter_type):
+    attrib_converter = Mock()
+    attrib_converter.side_effect = lambda val: str(val)
+
+    converter = converter_type(prefer_attrib_converters=True)
+    cl = make_class(
+        "HasConverter",
+        {
+            # non-built-in type with custom converter
+            "ip": attrib(
+                type=Union[IPv4Address, IPv6Address], converter=ip_address
+            ),
+            # attribute without type
+            "x": attrib(converter=attrib_converter),
+            # built-in types converters
+            "z": attrib(type=int, converter=attrib_converter),
+        },
+    )
+
+    inst = converter.structure(dict(ip="10.0.0.0", x=1, z=3), cl)
+
+    assert inst.ip == IPv4Address("10.0.0.0")
+
+    attrib_converter.assert_any_call(1)
+    assert inst.x == "1"
+
+    attrib_converter.assert_any_call(3)
+    assert inst.z == "3"

--- a/tests/test_structure_attrs.py
+++ b/tests/test_structure_attrs.py
@@ -166,7 +166,6 @@ def test_structure_literal(converter_cls):
     ) == ClassWithLiteral(4)
 
 
-
 @pytest.mark.parametrize("converter_type", [Converter, GenConverter])
 def test_structure_fallback_to_attrib_converters(converter_type):
     attrib_converter = Mock()

--- a/tests/test_structure_attrs.py
+++ b/tests/test_structure_attrs.py
@@ -217,11 +217,13 @@ def test_structure_prefers_attrib_converters(converter_type):
             # attribute without type
             "x": attrib(converter=attrib_converter),
             # built-in types converters
-            "z": attrib(type=int, converter=attrib_converter),
+            "y": attrib(type=int, converter=attrib_converter),
+            # attribute with type and default value
+            "z": attrib(type=int, converter=attrib_converter, default=5),
         },
     )
 
-    inst = converter.structure(dict(ip="10.0.0.0", x=1, z=3), cl)
+    inst = converter.structure(dict(ip="10.0.0.0", x=1, y=3), cl)
 
     assert inst.ip == IPv4Address("10.0.0.0")
 
@@ -229,4 +231,7 @@ def test_structure_prefers_attrib_converters(converter_type):
     assert inst.x == "1"
 
     attrib_converter.assert_any_call(3)
-    assert inst.z == "3"
+    assert inst.y == "3"
+
+    attrib_converter.assert_any_call(5)
+    assert inst.z == "5"


### PR DESCRIPTION
Resolves https://github.com/Tinche/cattrs/issues/138

If an attrs class has defined a converter with  `attr.ib`, fallback that instead if dispatching to cattrs converters fails to find a handler.

Also, add a new option `prefer_attrib_converters` to use them if defined instead of handlers registered in cattrs.
