### PR TITLE
Improve type inference in register_{un,}structure_hook

### DIFF
--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -162,7 +162,7 @@ class Converter(object):
         )
 
     def register_unstructure_hook(
-        self, cls: Any, func: Callable[[T], Any]
+        self, cls: Type[T], func: Callable[[T], Any]
     ) -> None:
         """Register a class-to-primitive converter function for a class.
 
@@ -187,7 +187,7 @@ class Converter(object):
         self._unstructure_func.register_func_list([(check_func, func)])
 
     def register_structure_hook(
-        self, cl: Any, func: Callable[[Any, Type[T]], T]
+        self, cl: Type[T], func: Callable[[Any, Type[T]], T]
     ):
         """Register a primitive-to-class converter function for a type.
 


### PR DESCRIPTION
Previously, the following line

```py
converter.register_unstructure_hook(datetime.date, lambda dt: dt.isoformat())
```

causes a mypy error

```
Cannot infer type argument 1 of "register_unstructure_hook" of "Converter"  [misc]
```

because the type of `register_unstructure_hook` was

```py
def register_unstructure_hook(self, cls: Any, func: Callable[[T], Any]) -> None: ...
```

and the `lambda` does not specify the `T`.

A workaround is to use a `def` instead of the `lambda` which specifies
the argument type, thus allowing mypy to infer `T`, but this is a bit
annoying.

Instead, change the `cls: Any` to `cls: Type[T]`, allowing mypy to bind
`T` to the given `cls` already. This also verifies that `cls` and
`func` are consistent.