### PR TITLE
Mark as requiring Python 3.7 and higher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ known_first_party = ["cattr"]
 [tool.poetry]
 name = "cattrs"
 version = "1.7.0dev0"
+requires-python = ">=3.7"
 description = "Composable complex class support for attrs and dataclasses."
 authors = ["Tin Tvrtkovic <tinchester@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
The incompatible change seems to have been introduced in 1.1.0 (in https://github.com/Tinche/cattrs/pull/98) and we cannot fix those packages retroactively but we can at least mark it going forward.