### PR TITLE
Various test suite compatibility improvements

### DIFF
--- a/tests/test_preconf.py
+++ b/tests/test_preconf.py
@@ -5,8 +5,6 @@ from json import loads as json_loads
 from typing import Dict, List
 
 from attr import define
-from bson import dumps as bson_dumps
-from bson import loads as bson_loads
 from hypothesis import given
 from hypothesis.strategies import (
     binary,
@@ -22,15 +20,6 @@ from hypothesis.strategies import (
     sets,
     text,
 )
-from msgpack import dumps as msgpack_dumps
-from msgpack import loads as msgpack_loads
-from orjson import dumps as orjson_dumps
-from orjson import loads as orjson_loads
-from tomlkit import dumps as tomlkit_dumps
-from tomlkit import loads as tomlkit_loads
-from ujson import dumps as ujson_dumps
-from ujson import loads as ujson_loads
-from yaml import safe_dump, safe_load
 
 from cattr._compat import (
     Counter,
@@ -194,6 +183,8 @@ def test_stdlib_json(everything: Everything):
     )
 )
 def test_ujson(everything: Everything):
+    from ujson import dumps as ujson_dumps
+    from ujson import loads as ujson_loads
     converter = ujson_make_converter()
     raw = ujson_dumps(converter.unstructure(everything))
     assert (
@@ -213,6 +204,8 @@ def test_ujson(everything: Everything):
     )
 )
 def test_orjson(everything: Everything):
+    from orjson import dumps as orjson_dumps
+    from orjson import loads as orjson_loads
     converter = orjson_make_converter()
     raw = orjson_dumps(converter.unstructure(everything))
     assert (
@@ -226,6 +219,8 @@ def test_orjson(everything: Everything):
 
 @given(everythings(min_int=-9223372036854775808, max_int=18446744073709551615))
 def test_msgpack(everything: Everything):
+    from msgpack import dumps as msgpack_dumps
+    from msgpack import loads as msgpack_loads
     converter = msgpack_make_converter()
     raw = msgpack_dumps(converter.unstructure(everything))
     assert (
@@ -246,6 +241,8 @@ def test_msgpack(everything: Everything):
     )
 )
 def test_bson(everything: Everything):
+    from bson import dumps as bson_dumps
+    from bson import loads as bson_loads
     converter = bson_make_converter()
     raw = bson_dumps(converter.unstructure(everything))
     assert (
@@ -259,6 +256,7 @@ def test_bson(everything: Everything):
 
 @given(everythings())
 def test_pyyaml(everything: Everything):
+    from yaml import safe_dump, safe_load
     converter = pyyaml_make_converter()
     unstructured = converter.unstructure(everything)
     raw = safe_dump(unstructured)
@@ -280,6 +278,8 @@ def test_pyyaml(everything: Everything):
     )
 )
 def test_tomlkit(everything: Everything):
+    from tomlkit import dumps as tomlkit_dumps
+    from tomlkit import loads as tomlkit_loads
     converter = tomlkit_make_converter()
     unstructured = converter.unstructure(everything)
     raw = tomlkit_dumps(unstructured)

--- a/tox.ini
+++ b/tox.ini
@@ -24,10 +24,11 @@ commands =
     isort --check src tests docs/conf.py
 
 [testenv]
-whitelist_externals = poetry
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/cattr
 extras = dev
+deps =
+    poetry
 commands =
     poetry install -v --no-root
     coverage run --source cattr -m pytest tests

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     poetry
 commands =
     poetry install -v --no-root
-    coverage run --source cattr -m pytest tests
+    coverage run --source cattr -m pytest tests {posargs}
 passenv = CI
 
 [testenv:docs]


### PR DESCRIPTION
1. Install `poetry` inside tox not to require external install of poetry.
2. Support passing additional args to pytest via tox.
3. <del>Skip respective `test_preconf` tests when deps are missing instead of failing.</del> <ins>Move test-related imports to test functions.</ins>
4. <del>Skip bson tests if incompatible `bson` module from pymongo is installed.</del>