### PR TITLE
DRAFT for illustration: add optional namespace kws to pass into resolve_types

### DIFF
--- a/src/cattr/gen.py
+++ b/src/cattr/gen.py
@@ -139,6 +139,8 @@ def make_dict_structure_fn(
     _cattrs_forbid_extra_keys: bool = False,
     _cattrs_use_linecache: bool = True,
     _cattrs_prefer_attrib_converters: bool = False,
+    globalns: Optional[dict] = None,
+    localns: Optional[dict] = None,
     **kwargs,
 ):
     """Generate a specialized dict structuring function for an attrs class."""
@@ -177,7 +179,7 @@ def make_dict_structure_fn(
 
     if any(isinstance(a.type, str) for a in attrs):
         # PEP 563 annotations - need to be resolved.
-        resolve_types(cl)
+        resolve_types(cl, globalns=globalns)
 
     lines.append(f"def {fn_name}(o, *_):")
     lines.append("  res = {")

--- a/tests/nested_type_check_test/nested_a.py
+++ b/tests/nested_type_check_test/nested_a.py
@@ -1,0 +1,11 @@
+from typing import Optional
+import attr
+
+
+@attr.define
+class InnerA:
+    a: int
+    b: float
+    c: str
+    d: bytes
+    e: Optional[int] = None

--- a/tests/nested_type_check_test/nested_attr_o.py
+++ b/tests/nested_type_check_test/nested_attr_o.py
@@ -1,0 +1,13 @@
+from typing import TYPE_CHECKING
+import attr
+
+if TYPE_CHECKING:
+    from .nested_e import InnerE
+
+
+@attr.define
+class Outer:
+    a: InnerE
+    b: InnerE
+    c: InnerE
+    d: InnerE

--- a/tests/nested_type_check_test/nested_b.py
+++ b/tests/nested_type_check_test/nested_b.py
@@ -1,0 +1,12 @@
+from typing import Optional
+import attr
+
+from .nested_a import InnerA
+
+
+@attr.define
+class InnerB:
+    a: InnerA
+    b: InnerA
+    c: InnerA
+    d: Optional[InnerA] = None

--- a/tests/nested_type_check_test/nested_c.py
+++ b/tests/nested_type_check_test/nested_c.py
@@ -1,0 +1,12 @@
+from typing import Optional
+import attr
+
+from .nested_b import InnerB
+
+
+@attr.define
+class InnerC:
+    a: InnerB
+    b: InnerB
+    c: InnerB
+    d: InnerB

--- a/tests/nested_type_check_test/nested_d.py
+++ b/tests/nested_type_check_test/nested_d.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+import attr
+
+if TYPE_CHECKING:
+    from .nested_c import InnerC
+
+
+@attr.define
+class InnerD:
+    a: InnerC
+    b: InnerC
+    c: InnerC
+    d: InnerC

--- a/tests/nested_type_check_test/nested_e.py
+++ b/tests/nested_type_check_test/nested_e.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import attr
+
+if TYPE_CHECKING:
+    from .nested_d import InnerD
+
+
+@attr.define
+class InnerE:
+    a: InnerD
+    b: InnerD
+    c: InnerD
+    d: InnerD

--- a/tests/nested_type_check_test/nested_o.py
+++ b/tests/nested_type_check_test/nested_o.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+import attr
+
+if TYPE_CHECKING:
+    from .nested_e import InnerE
+
+
+@attr.define
+class Outer:
+    a: InnerE
+    b: InnerE
+    c: InnerE
+    d: InnerE

--- a/tests/test_deep_nest_custom_namespace.py
+++ b/tests/test_deep_nest_custom_namespace.py
@@ -1,0 +1,33 @@
+import pytest
+
+from cattr.preconf.pyyaml import make_converter as yaml_converter
+import attr
+import yaml
+import io
+
+from .nested_type_check_test.nested_a import InnerA
+from .nested_type_check_test.nested_b import InnerB
+from .nested_type_check_test.nested_c import InnerC
+from .nested_type_check_test.nested_d import InnerD
+from .nested_type_check_test.nested_e import InnerE
+from .nested_type_check_test.nested_o import Outer
+
+
+# make False first as the caching of yaml converter causes False to pass
+# if second
+@pytest.mark.parametrize("register_namespace", [False, True])
+def test_unstruct_attrs_deep_nest(register_namespace):
+    c = yaml_converter()
+    if register_namespace:
+        c.register_namespace(globals())
+    make_inner_a = lambda: InnerA(1, 1.0, "one", "one".encode())
+    make_inner_b = lambda: InnerB(*[make_inner_a() for _ in range(4)])
+    make_inner_c = lambda: InnerC(*[make_inner_b() for _ in range(4)])
+    make_inner_d = lambda: InnerD(*[make_inner_c() for _ in range(4)])
+    make_inner_e = lambda: InnerE(*[make_inner_d() for _ in range(4)])
+
+    inst = Outer(*[make_inner_e() for _ in range(4)])
+    unstruct = c.unstructure(inst)
+    b = c.structure(unstruct, Outer)
+
+    assert inst == b


### PR DESCRIPTION
This is related to issue #160 

In the case of type annotations which are imported in a TYPE_CHECKING block
the origin class will not contain them in their runtime namespace so cattrs was
unable to resolve them which structuring and unstructuring.  Added a method to
register a custom namespace with the Converter class which could be used when
resolving classes not in the default namespace.

A simple test of nesting when those annotations of nested types are coming from
type checking blocks and therefore not present at runtime.  The test file is
test_deep_nest_custom_namespace.py

Thank you for this awesome library, I've found it very helpful!
